### PR TITLE
[codex] add policy-aware tool execution

### DIFF
--- a/agi-project/src/chimera/agent/agent.py
+++ b/agi-project/src/chimera/agent/agent.py
@@ -45,6 +45,8 @@ class Agent:
         
         **Available Tools:**
         {self.tool_registry.get_tool_schemas()}
+
+        Only tools listed above are executable in the current policy mode.
         
         Based on the observation, your history, and your recalled experiences, what is your next action?
         Your response must be a JSON object that strictly adheres to the schema of one of the available tools.
@@ -89,15 +91,7 @@ class Agent:
 
     def _act(self, action: Any) -> Any:
         """Executes the chosen action using the tool registry."""
-        try:
-            tool_name = action["tool_name"]
-            arguments = action["arguments"]
-            tool = self.tool_registry.get_tool(tool_name)
-            result = tool(**arguments)
-            outcome = {"source_tool": tool.name, "data": {"text_data": result}, "is_error": False}
-        except Exception as e:
-            outcome = {"source_tool": action.get("tool_name", "unknown_tool"), "data": {"text_data": str(e)}, "is_error": True}
-        return outcome
+        return self.tool_registry.execute_action(action)
 
     def run_main_loop(self, initial_observation: Any):
         """Runs the main perceive-think-act loop of the agent."""

--- a/agi-project/src/chimera/agent/tool_user.py
+++ b/agi-project/src/chimera/agent/tool_user.py
@@ -3,7 +3,28 @@
 import abc
 import json
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    """Execution policy metadata for a tool."""
+
+    risk_level: str = "medium"
+    capabilities: tuple[str, ...] = ()
+    allowed_by_default: bool = True
+    requires_approval: bool = False
+    policy_note: str = ""
+
+    def to_prompt_dict(self) -> Dict[str, Any]:
+        """Returns a JSON-serializable view of the policy."""
+        return {
+            "risk_level": self.risk_level,
+            "capabilities": list(self.capabilities),
+            "allowed_by_default": self.allowed_by_default,
+            "requires_approval": self.requires_approval,
+            "policy_note": self.policy_note,
+        }
 
 class Tool(abc.ABC):
     """Abstract Base Class for a tool that the agent can use."""
@@ -30,11 +51,22 @@ class Tool(abc.ABC):
         """Executes the tool with the given arguments."""
         pass
 
+    def get_policy(self) -> ToolPolicy:
+        """Returns execution policy metadata for the tool."""
+        return ToolPolicy()
+
+    def get_prompt_schema(self) -> Dict[str, Any]:
+        """Returns the schema enriched with policy metadata for prompt rendering."""
+        schema = dict(self.get_schema())
+        schema["x-tool-policy"] = self.get_policy().to_prompt_dict()
+        return schema
+
 class ToolRegistry:
     """A registry that holds and provides access to all available tools."""
 
-    def __init__(self):
+    def __init__(self, allow_restricted_tools: bool = False):
         self._tools: Dict[str, Tool] = {}
+        self.allow_restricted_tools = allow_restricted_tools
 
     def register_tool(self, tool: Tool):
         """Registers a new tool."""
@@ -54,14 +86,119 @@ class ToolRegistry:
             raise ValueError(f"Tool with name '{name}' not found.")
         del self._tools[name]
 
-    def get_tool_schemas(self) -> str:
-        """Returns a JSON string of all tool schemas."""
-        schemas = {name: tool.get_schema() for name, tool in self._tools.items()}
+    def get_tool_schemas(self, include_restricted: bool | None = None) -> str:
+        """Returns a JSON string of all prompt-visible tool schemas."""
+        if include_restricted is None:
+            include_restricted = self.allow_restricted_tools
+
+        schemas = {
+            name: tool.get_prompt_schema()
+            for name, tool in self._tools.items()
+            if include_restricted or tool.get_policy().allowed_by_default
+        }
         return json.dumps(schemas, indent=2)
 
     def get_tool_names(self) -> List[str]:
         """Returns a list of all registered tool names."""
         return list(self._tools.keys())
+
+    def execute_tool(
+        self,
+        name: str,
+        arguments: Dict[str, Any] | None = None,
+        allow_restricted: bool | None = None,
+    ) -> Dict[str, Any]:
+        """Executes a tool with policy checks and structured outcomes."""
+        arguments = arguments or {}
+        if not isinstance(arguments, dict):
+            return self._build_outcome(
+                source_tool=name,
+                text_data="Tool arguments must be a JSON object.",
+                is_error=True,
+                status="invalid_arguments",
+            )
+
+        try:
+            tool = self.get_tool(name)
+        except ValueError as exc:
+            return self._build_outcome(
+                source_tool=name,
+                text_data=str(exc),
+                is_error=True,
+                status="unknown_tool",
+            )
+
+        policy = tool.get_policy()
+        if allow_restricted is None:
+            allow_restricted = self.allow_restricted_tools
+
+        if not policy.allowed_by_default and not allow_restricted:
+            note = policy.policy_note or "This tool requires an explicit policy override."
+            return self._build_outcome(
+                source_tool=tool.name,
+                text_data=f"Tool '{tool.name}' is restricted by policy. {note}",
+                is_error=True,
+                status="blocked",
+                tool=tool,
+            )
+
+        try:
+            result = tool(**arguments)
+            return self._build_outcome(
+                source_tool=tool.name,
+                text_data=result,
+                is_error=False,
+                status="executed",
+                tool=tool,
+            )
+        except Exception as exc:
+            return self._build_outcome(
+                source_tool=tool.name,
+                text_data=str(exc),
+                is_error=True,
+                status="execution_error",
+                tool=tool,
+            )
+
+    def execute_action(self, action: Any, allow_restricted: bool | None = None) -> Dict[str, Any]:
+        """Executes a structured agent action via the policy-aware tool path."""
+        if not isinstance(action, dict):
+            return self._build_outcome(
+                source_tool="unknown_tool",
+                text_data="Agent action must be a JSON object.",
+                is_error=True,
+                status="invalid_action",
+            )
+
+        tool_name = action.get("tool_name")
+        arguments = action.get("arguments", {})
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            return self._build_outcome(
+                source_tool="unknown_tool",
+                text_data="Agent action is missing a valid 'tool_name'.",
+                is_error=True,
+                status="invalid_action",
+            )
+
+        return self.execute_tool(tool_name, arguments, allow_restricted=allow_restricted)
+
+    def _build_outcome(
+        self,
+        source_tool: str,
+        text_data: Any,
+        is_error: bool,
+        status: str,
+        tool: Tool | None = None,
+    ) -> Dict[str, Any]:
+        policy = {"status": status}
+        if tool is not None:
+            policy.update(tool.get_policy().to_prompt_dict())
+        return {
+            "source_tool": source_tool,
+            "data": {"text_data": text_data},
+            "is_error": is_error,
+            "policy": policy,
+        }
 
 # --- Tool Implementations ---
 
@@ -91,6 +228,15 @@ class WebSearchTool(Tool):
                 "required": ["query"]
             }
         }
+
+    def get_policy(self) -> ToolPolicy:
+        return ToolPolicy(
+            risk_level="medium",
+            capabilities=("web.search", "web.scrape"),
+            allowed_by_default=True,
+            requires_approval=False,
+            policy_note="Use for open-web research and summarization tasks.",
+        )
 
     def __call__(self, query: str) -> str:
         print(f"--- EXECUTING WEB SEARCH AND SCRAPE: {query} ---")
@@ -151,6 +297,15 @@ class FileSystemTool(Tool):
                 "required": ["operation", "path"]
             }
         }
+
+    def get_policy(self) -> ToolPolicy:
+        return ToolPolicy(
+            risk_level="high",
+            capabilities=("filesystem.list", "filesystem.read"),
+            allowed_by_default=False,
+            requires_approval=True,
+            policy_note="Reads from the host file system and should stay gated unless explicitly enabled.",
+        )
 
     def __call__(self, operation: str, path: str) -> str:
         try:

--- a/agi-project/src/chimera/consciousness/conscious_agent.py
+++ b/agi-project/src/chimera/consciousness/conscious_agent.py
@@ -124,6 +124,7 @@ class ConsciousnessAwareAgent:
         # Add available tools
         prompt_parts.extend([
             f"**Available Tools:**\n{self.tool_registry.get_tool_schemas()}\n",
+            "Only tools listed above are executable in the current policy mode.\n",
             f"Based on the observation, your history, your recalled experiences, and your self-reflection, what is your next action?",
             f"Your response must be a JSON object that strictly adheres to the schema of one of the available tools.",
             f"For example:\n{{\n    \"tool_name\": \"tool_name\",\n    \"arguments\": {{\n        \"arg1\": \"value1\",\n        \"arg2\": \"value2\"\n    }}\n}}"
@@ -166,15 +167,7 @@ class ConsciousnessAwareAgent:
 
     def _act(self, action: Any) -> Any:
         """Execute the chosen action using the tool registry"""
-        try:
-            tool_name = action["tool_name"]
-            arguments = action["arguments"]
-            tool = self.tool_registry.get_tool(tool_name)
-            result = tool(**arguments)
-            outcome = {"source_tool": tool.name, "data": {"text_data": result}, "is_error": False}
-        except Exception as e:
-            outcome = {"source_tool": action.get("tool_name", "unknown_tool"), "data": {"text_data": str(e)}, "is_error": True}
-        return outcome
+        return self.tool_registry.execute_action(action)
 
     def run_main_loop(self, initial_observation: Any):
         """Run the main perceive-think-act loop with consciousness awareness"""

--- a/agi-project/tests/test_agent_logic.py
+++ b/agi-project/tests/test_agent_logic.py
@@ -5,7 +5,8 @@ import pytest
 
 from chimera.agent.agent import Agent
 from chimera.agent.memory import Experience
-from chimera.agent.tool_user import Tool, ToolRegistry
+from chimera.agent.tool_user import Tool, ToolPolicy, ToolRegistry
+from chimera.consciousness.conscious_agent import ConsciousnessAwareAgent
 from chimera.cognitive_core.interfaces import CognitiveCore
 
 # --- Mock Components ---
@@ -111,8 +112,10 @@ class MockCognitiveCore(CognitiveCore):
     """A mock cognitive core that returns a predefined JSON action."""
     def __init__(self, action_json: Dict[str, Any]):
         self.action_json = action_json
+        self.prompts: list[Dict[str, Any]] = []
 
-    def generate_response(self, prompt: Dict[str, str]) -> str:
+    def generate_response(self, prompt: Dict[str, Any], temperature: float = 0.7) -> str:
+        self.prompts.append(prompt)
         return json.dumps(self.action_json)
 
     def load_model(self, model_path: str):
@@ -151,6 +154,41 @@ class SumTool(Tool):
     def __call__(self, a: int, b: int) -> Any:
         return a + b
 
+
+class RestrictedEchoTool(Tool):
+    @property
+    def name(self) -> str:
+        return "restricted_echo"
+
+    @property
+    def description(self) -> str:
+        return "Echoes a payload, but only when explicitly enabled."
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "payload": {"type": "string"},
+                },
+                "required": ["payload"],
+            },
+        }
+
+    def get_policy(self) -> ToolPolicy:
+        return ToolPolicy(
+            risk_level="high",
+            capabilities=("debug.echo",),
+            allowed_by_default=False,
+            requires_approval=True,
+            policy_note="Test-only restricted tool.",
+        )
+
+    def __call__(self, payload: str) -> Any:
+        return payload
+
 # --- Test Fixture ---
 
 @pytest.fixture(autouse=True)
@@ -182,6 +220,16 @@ def setup_agent_for_test(db_path: str):
         cognitive_core=mock_core,
         tool_registry=tool_registry,
         db_path=db_path
+    )
+    return agent
+
+
+def setup_conscious_agent_for_test(db_path: str, action_json: Dict[str, Any], tool_registry: ToolRegistry):
+    mock_core = MockCognitiveCore(action_json=action_json)
+    agent = ConsciousnessAwareAgent(
+        cognitive_core=mock_core,
+        tool_registry=tool_registry,
+        db_path=db_path,
     )
     return agent
 
@@ -224,3 +272,89 @@ def test_agent_vector_memory_and_recall(temp_db_path):
         "The recalled experience should match the one that was remembered."
 
     print("Agent vector memory (remember and recall) test passed successfully!")
+
+
+def test_tool_registry_hides_restricted_tools_from_prompt_by_default():
+    registry = ToolRegistry()
+    registry.register_tool(SumTool())
+    registry.register_tool(RestrictedEchoTool())
+
+    prompt_schemas = json.loads(registry.get_tool_schemas())
+    assert "sum_numbers" in prompt_schemas
+    assert "restricted_echo" not in prompt_schemas
+
+    all_schemas = json.loads(registry.get_tool_schemas(include_restricted=True))
+    assert all_schemas["restricted_echo"]["x-tool-policy"]["allowed_by_default"] is False
+    assert all_schemas["restricted_echo"]["x-tool-policy"]["risk_level"] == "high"
+
+
+def test_tool_registry_blocks_restricted_tools_by_default():
+    registry = ToolRegistry()
+    registry.register_tool(RestrictedEchoTool())
+
+    outcome = registry.execute_action({
+        "tool_name": "restricted_echo",
+        "arguments": {"payload": "secret"},
+    })
+
+    assert outcome["is_error"] is True
+    assert outcome["policy"]["status"] == "blocked"
+    assert "restricted by policy" in outcome["data"]["text_data"]
+
+
+def test_tool_registry_executes_restricted_tools_when_enabled():
+    registry = ToolRegistry(allow_restricted_tools=True)
+    registry.register_tool(RestrictedEchoTool())
+
+    outcome = registry.execute_action({
+        "tool_name": "restricted_echo",
+        "arguments": {"payload": "secret"},
+    })
+
+    assert outcome["is_error"] is False
+    assert outcome["policy"]["status"] == "executed"
+    assert outcome["data"]["text_data"] == "secret"
+
+
+def test_tool_registry_returns_structured_unknown_tool_error():
+    registry = ToolRegistry()
+    outcome = registry.execute_action({
+        "tool_name": "missing_tool",
+        "arguments": {},
+    })
+
+    assert outcome["is_error"] is True
+    assert outcome["policy"]["status"] == "unknown_tool"
+    assert "not found" in outcome["data"]["text_data"]
+
+
+def test_agent_act_uses_policy_aware_tool_execution(temp_db_path):
+    registry = ToolRegistry()
+    registry.register_tool(RestrictedEchoTool())
+    agent = Agent(
+        cognitive_core=MockCognitiveCore(
+            {"tool_name": "restricted_echo", "arguments": {"payload": "secret"}}
+        ),
+        tool_registry=registry,
+        db_path=temp_db_path,
+    )
+
+    outcome = agent._act({"tool_name": "restricted_echo", "arguments": {"payload": "secret"}})
+
+    assert outcome["is_error"] is True
+    assert outcome["policy"]["status"] == "blocked"
+
+
+def test_conscious_agent_act_uses_policy_aware_tool_execution(temp_db_path):
+    registry = ToolRegistry()
+    registry.register_tool(RestrictedEchoTool())
+    agent = setup_conscious_agent_for_test(
+        db_path=temp_db_path,
+        action_json={"tool_name": "restricted_echo", "arguments": {"payload": "secret"}},
+        tool_registry=registry,
+    )
+
+    outcome = agent._act({"tool_name": "restricted_echo", "arguments": {"payload": "secret"}})
+
+    assert outcome["is_error"] is True
+    assert outcome["policy"]["status"] == "blocked"


### PR DESCRIPTION
## What changed

This adds a clean-room policy layer around Project Chimera's tool runtime.

- adds `ToolPolicy` metadata to tools, including risk level, capabilities, and default availability
- enriches prompt-visible tool schemas with policy metadata
- hides restricted tools from the default prompt surface unless explicitly enabled
- routes tool execution through `ToolRegistry.execute_action(...)` so unknown, blocked, and runtime-error cases return structured outcomes
- applies the shared execution path to both `Agent` and `ConsciousnessAwareAgent`
- adds focused tests for prompt exposure, blocked/allowed execution, unknown-tool handling, and both agent execution paths

## Why

Right now the agent stack exposes tool schemas to the model and then directly executes whatever tool/action comes back. That makes it hard to distinguish safe default tools from host-sensitive ones like file-system access, and it duplicates the same raw execution behavior across the standard and consciousness-aware agents.

This PR adds the first policy-aware execution slice without attempting a large planner/runtime refactor.

## Impact

- default prompt exposure is now safer and more explicit
- the file-system tool is gated by default instead of being silently available
- both agent variants now share the same policy-aware execution behavior
- future approval flows or capability gating can build on the registry instead of patching each agent separately

## Validation

- `python3 -m py_compile src/chimera/agent/tool_user.py src/chimera/agent/agent.py src/chimera/consciousness/conscious_agent.py tests/test_agent_logic.py`
- `PYTHONPATH=src /tmp/project-chimera-venv/bin/python -m pytest -c /dev/null tests/test_agent_logic.py tests/test_consciousness.py tests/test_consciousness_simple.py`
- `git diff --check`

## Notes

- I intentionally did not touch the existing merge-conflict markers in `agi-project/pyproject.toml`, so validation was run directly via `python`/`pytest` instead of Poetry-driven commands.
