### PR TITLE
[codex] Add standalone Chimera CLI

### DIFF
--- a/agi-project/README.md
+++ b/agi-project/README.md
@@ -9,6 +9,7 @@ This directory contains the core Python package (`src/chimera/`) and all support
 ```
 agi-project/
 ├── src/chimera/                 # The core package (importable as `chimera.*`)
+│   ├── main.py                  #   Standalone CLI entry point (`python -m chimera.main`)
 │   ├── cognitive_core/          # Prometheus — LLM abstraction
 │   │   ├── interfaces.py        #   CognitiveCore ABC (implement this for new LLM backends)
 │   │   ├── prometheus_core.py   #   Gemini 1.5 Flash implementation
@@ -36,6 +37,7 @@ agi-project/
 │
 ├── tests/                       # Test suite
 │   ├── test_agent_logic.py      #   Agent + memory + tool tests
+│   ├── test_main.py             #   Standalone CLI tests
 │   ├── test_consciousness.py    #   Full Narcissus integration tests
 │   └── test_consciousness_simple.py  # Unit tests for consciousness components
 │
@@ -69,6 +71,21 @@ poetry run pytest tests/ -v
 PYTHONPATH=src pytest tests/ -v
 ```
 
+## Running Chimera Standalone
+
+```bash
+# Single prompt, standard agent
+PYTHONPATH=src python -m chimera.main --prompt "Research the latest open-source vector databases" --json
+
+# Consciousness-aware interactive shell
+PYTHONPATH=src python -m chimera.main --mode consciousness
+
+# Opt in to the read-only file system tool
+PYTHONPATH=src python -m chimera.main --allow-file-system --prompt "List the files in the current directory"
+```
+
+The standalone CLI exposes web search by default. Local file-system access is available only when `--allow-file-system` is passed.
+
 ## Key Classes
 
 | Class | Module | Purpose |
@@ -100,3 +117,5 @@ Releases that are compatible with Knight Medicare are tagged `v0.x.x-km-ready`. 
 | `v0.2.0-km-ready` | Clean restructure, modules at `src/chimera/*`, shims at old paths, large files removed |
 | `v0.3.0-km-ready` | (planned) `chimera/__init__.py` fix |
 | `v0.4.0-standalone` | (planned) Standalone CLI + package restructure |
+
+The Knight Medicare integration roadmap now lives in [docs/KNIGHT_MEDICARE_INTEGRATION_PLAN.md](docs/KNIGHT_MEDICARE_INTEGRATION_PLAN.md). It reflects how KM actually consumes Chimera today: as a memory and consciousness core behind a thin FastAPI bridge.

--- a/agi-project/docs/KNIGHT_MEDICARE_INTEGRATION_PLAN.md
+++ b/agi-project/docs/KNIGHT_MEDICARE_INTEGRATION_PLAN.md
@@ -1,0 +1,69 @@
+# Chimera and Knight Medicare
+
+This roadmap turns the current Knight Medicare integration into a cleaner package contract for `chimera`.
+
+## What Knight Medicare Uses Today
+
+Knight Medicare vendors Chimera as a library and mostly relies on three subsystems:
+
+- `chimera.agent.memory` for `VectorEpisodicMemory` and `WorkingMemory`
+- `chimera.consciousness` for `NarcissusConsciousnessCore` and `ConsciousnessIntegration`
+- the package structure itself, via `chimera-bridge`, which wraps Chimera behind FastAPI routes
+
+Knight Medicare does **not** currently use the standalone `Agent` or `ConsciousnessAwareAgent` loop for therapy. Its `chimera-bridge/adapters/km_agent.py` runs a separate single-turn therapy pipeline with its own prompts, async provider, and therapy-tool registry.
+
+That means Chimera's next job is not "move all Knight Medicare code into core overnight." The next job is to become easier to run standalone and easier to embed safely.
+
+## Package Priorities
+
+### Phase 1: Standalone Parity
+
+Ship the minimum surfaces needed for local usage and demos:
+
+- a supported `python -m chimera.main` entrypoint
+- a reusable single-turn runner that mirrors the observe-think-act cycle
+- opt-in local file-system access rather than exposing it by default
+- docs that explain how standalone mode differs from Knight Medicare mode
+
+This PR covers that phase.
+
+### Phase 2: Stable Adapter Seams
+
+Create explicit extension points so downstream apps stop importing deep internals ad hoc:
+
+- `chimera.adapters.therapy` for Knight Medicare's therapy loop
+- `chimera.providers` for sync and async LLM backends
+- `chimera.tools` for domain-specific tool packs such as therapy interventions
+- a shared response shape for single-turn runs, tool outcomes, and memory writes
+
+The goal is to let Knight Medicare depend on supported interfaces instead of carrying a parallel orchestration layer forever.
+
+### Phase 3: Provenance and Safety
+
+Bring clean-room lessons from modern agent runtimes into Chimera itself:
+
+- turn-level run metadata for prompts, tool calls, and outcomes
+- critique hooks before returning high-risk responses
+- guardrails for tool exposure and domain-sensitive behavior
+- policy-aware configuration for future restricted capabilities
+
+This matters more for Knight Medicare than for the standalone demo because therapy flows need traceability.
+
+### Phase 4: Research Features After the Core Is Stable
+
+After the package boundaries are solid, Chimera can absorb higher-order work like:
+
+- local emotion models
+- constitutional checks
+- multi-agent orchestration
+- local fallback LLM providers
+- richer reflection loops
+
+Knight Medicare's own strategy docs are directionally right here: the foundation should come before extra AGI breadth.
+
+## Recommended Ownership Split
+
+- Chimera repo owns core cognition, memory, consciousness, CLI, adapters, providers, and reusable tools.
+- Knight Medicare owns product prompts, patient workflows, clinician UX, web APIs, and app-specific safety policies.
+
+That split keeps Chimera reusable while letting Knight Medicare iterate on therapy behavior quickly.

--- a/agi-project/src/chimera/main.py
+++ b/agi-project/src/chimera/main.py
@@ -1,0 +1,174 @@
+"""Standalone CLI entrypoint for Project Chimera."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .agent.agent import Agent
+from .agent.memory import Experience
+from .agent.tool_user import FileSystemTool, ToolRegistry, WebSearchTool
+from .consciousness.conscious_agent import ConsciousnessAwareAgent
+
+DEFAULT_DB_PATH = Path(os.environ.get("CHIMERA_DB_PATH", ".chimera")).expanduser()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for standalone Chimera usage."""
+    parser = argparse.ArgumentParser(
+        prog="chimera",
+        description=(
+            "Run Project Chimera as a standalone research agent. "
+            "By default it exposes web search only; local file-system access stays opt-in."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("standard", "consciousness"),
+        default="standard",
+        help="Select the base agent loop or the consciousness-aware variant.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=str(DEFAULT_DB_PATH),
+        help="Directory used for LanceDB-backed episodic memory.",
+    )
+    parser.add_argument(
+        "--prompt",
+        help="Run a single prompt and exit. Without this flag, Chimera starts an interactive shell.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print each turn as JSON instead of a human-readable summary.",
+    )
+    parser.add_argument(
+        "--allow-file-system",
+        action="store_true",
+        help="Register the local file-system tool for read-only exploration.",
+    )
+    return parser
+
+
+def build_initial_observation(prompt: str) -> dict[str, Any]:
+    """Normalize a user prompt into the observation structure used across Chimera."""
+    return {"source": "user", "data": {"text_data": prompt}}
+
+
+def create_tool_registry(*, allow_file_system: bool = False) -> ToolRegistry:
+    """Create the default standalone tool registry."""
+    registry = ToolRegistry()
+    registry.register_tool(WebSearchTool())
+    if allow_file_system:
+        registry.register_tool(FileSystemTool())
+    return registry
+
+
+def create_agent(
+    *,
+    mode: str,
+    db_path: str,
+    tool_registry: ToolRegistry | None = None,
+    cognitive_core: Any | None = None,
+) -> Agent | ConsciousnessAwareAgent:
+    """Create a configured Chimera agent instance."""
+    tool_registry = tool_registry or create_tool_registry()
+    if cognitive_core is None:
+        from .cognitive_core.prometheus_core import PrometheusCognitiveCore
+
+        cognitive_core = PrometheusCognitiveCore()
+
+    agent_cls = ConsciousnessAwareAgent if mode == "consciousness" else Agent
+    return agent_cls(
+        cognitive_core=cognitive_core,
+        tool_registry=tool_registry,
+        db_path=db_path,
+    )
+
+
+def run_agent_turn(
+    agent: Agent | ConsciousnessAwareAgent,
+    prompt: str,
+) -> dict[str, Any]:
+    """Run a single observe-think-act cycle and persist the resulting experience."""
+    observation = build_initial_observation(prompt)
+    agent.working_memory.add(observation)
+
+    action = agent._think(observation)
+    agent.working_memory.add(action)
+
+    outcome = agent._act(action)
+    agent.working_memory.add(outcome)
+
+    agent.episodic_memory.remember(
+        Experience(observation=observation, action=action, outcome=outcome)
+    )
+
+    return {
+        "observation": observation,
+        "action": action,
+        "outcome": outcome,
+    }
+
+
+def _print_turn(turn: dict[str, Any], *, as_json: bool) -> None:
+    """Render a completed turn for either humans or scripts."""
+    if as_json:
+        print(json.dumps(turn, indent=2))
+        return
+
+    action = turn["action"]
+    outcome = turn["outcome"]
+    print(f"Action: {action.get('tool_name', 'unknown')}")
+    print(json.dumps(action.get("arguments", {}), indent=2))
+    print("Outcome:")
+    print(json.dumps(outcome, indent=2))
+
+
+def _run_interactive_shell(
+    agent: Agent | ConsciousnessAwareAgent,
+    *,
+    as_json: bool,
+) -> int:
+    """Run the lightweight interactive shell."""
+    print("Chimera interactive shell started. Type 'exit' or 'quit' to stop.")
+    while True:
+        try:
+            prompt = input("chimera> ").strip()
+        except EOFError:
+            print()
+            return 0
+
+        if not prompt:
+            continue
+        if prompt.lower() in {"exit", "quit"}:
+            return 0
+
+        turn = run_agent_turn(agent, prompt)
+        _print_turn(turn, as_json=as_json)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint used by `python -m chimera.main`."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    agent = create_agent(
+        mode=args.mode,
+        db_path=str(Path(args.db_path).expanduser()),
+        tool_registry=create_tool_registry(allow_file_system=args.allow_file_system),
+    )
+
+    if args.prompt:
+        turn = run_agent_turn(agent, args.prompt)
+        _print_turn(turn, as_json=args.json)
+        return 0
+
+    return _run_interactive_shell(agent, as_json=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agi-project/tests/test_main.py
+++ b/agi-project/tests/test_main.py
@@ -1,0 +1,238 @@
+import json
+from typing import Any, Dict
+
+import pytest
+
+from chimera.agent.agent import Agent
+from chimera.agent.tool_user import Tool, ToolRegistry
+from chimera.cognitive_core.interfaces import CognitiveCore
+from chimera.main import (
+    build_initial_observation,
+    create_tool_registry,
+    main,
+    run_agent_turn,
+)
+
+
+class FakeSentenceTransformer:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 3
+
+    def encode(self, text: str):
+        length = float(len(text))
+        return [length, length / 2.0, 1.0]
+
+
+class FakeArrow:
+    @staticmethod
+    def schema(fields):
+        return fields
+
+    @staticmethod
+    def field(name, data_type):
+        return (name, data_type)
+
+    @staticmethod
+    def list_(data_type, embedding_dim):
+        return (data_type, embedding_dim)
+
+    @staticmethod
+    def float32():
+        return "float32"
+
+    @staticmethod
+    def string():
+        return "string"
+
+
+class FakeResults:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def iterrows(self):
+        for index, row in enumerate(self.rows):
+            yield index, row
+
+
+class FakeSearch:
+    def __init__(self, rows):
+        self.rows = rows
+        self._limit = len(rows)
+
+    def limit(self, top_k: int):
+        self._limit = top_k
+        return self
+
+    def to_df(self):
+        return FakeResults(self.rows[: self._limit])
+
+
+class FakeTable:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, rows):
+        self.rows.extend(rows)
+
+    def count_rows(self):
+        return len(self.rows)
+
+    def search(self, query_vector):
+        return FakeSearch(self.rows)
+
+
+class FakeDB:
+    def __init__(self):
+        self.tables = {}
+
+    def table_names(self):
+        return list(self.tables.keys())
+
+    def open_table(self, table_name):
+        return self.tables[table_name]
+
+    def create_table(self, table_name, schema):
+        table = FakeTable()
+        self.tables[table_name] = table
+        return table
+
+
+class FakeLanceDB:
+    def __init__(self):
+        self.databases = {}
+
+    def connect(self, path):
+        if path not in self.databases:
+            self.databases[path] = FakeDB()
+        return self.databases[path]
+
+
+class MockCognitiveCore(CognitiveCore):
+    def __init__(self, action_json: Dict[str, Any]):
+        self.action_json = action_json
+
+    def generate_response(self, prompt: Dict[str, Any]) -> str:
+        return json.dumps(self.action_json)
+
+    def load_model(self, model_path: str):
+        pass
+
+    def train(self, dataset: Any):
+        pass
+
+    def get_state(self) -> Any:
+        return None
+
+
+class SumTool(Tool):
+    @property
+    def name(self) -> str:
+        return "sum_numbers"
+
+    @property
+    def description(self) -> str:
+        return "Adds two numbers."
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+        }
+
+    def __call__(self, a: int, b: int) -> Any:
+        return a + b
+
+
+@pytest.fixture(autouse=True)
+def fake_embedding_model(monkeypatch):
+    fake_lancedb = FakeLanceDB()
+    monkeypatch.setattr(
+        "chimera.agent.memory._load_vector_dependencies",
+        lambda: (fake_lancedb, FakeArrow, FakeSentenceTransformer),
+    )
+
+
+def test_build_initial_observation():
+    observation = build_initial_observation("hello there")
+    assert observation == {"source": "user", "data": {"text_data": "hello there"}}
+
+
+def test_create_tool_registry_defaults_to_web_only():
+    registry = create_tool_registry()
+    assert "web_search" in registry.get_tool_names()
+    assert "file_system" not in registry.get_tool_names()
+
+
+def test_create_tool_registry_can_enable_file_system():
+    registry = create_tool_registry(allow_file_system=True)
+    assert "file_system" in registry.get_tool_names()
+
+
+def test_run_agent_turn_records_memory(tmp_path):
+    registry = ToolRegistry()
+    registry.register_tool(SumTool())
+    agent = Agent(
+        cognitive_core=MockCognitiveCore(
+            {"tool_name": "sum_numbers", "arguments": {"a": 2, "b": 3}}
+        ),
+        tool_registry=registry,
+        db_path=str(tmp_path),
+    )
+
+    turn = run_agent_turn(agent, "add these numbers")
+
+    assert turn["action"]["tool_name"] == "sum_numbers"
+    assert turn["outcome"]["data"]["text_data"] == 5
+    assert len(agent.working_memory.get_context()) == 3
+    assert agent.episodic_memory.table.count_rows() == 1
+
+
+class FakeWorkingMemory:
+    def __init__(self):
+        self.history = []
+
+    def add(self, record):
+        self.history.append(record)
+
+
+class FakeEpisodicMemory:
+    def __init__(self):
+        self.remembered = []
+
+    def remember(self, experience):
+        self.remembered.append(experience)
+
+
+class FakeAgent:
+    def __init__(self):
+        self.working_memory = FakeWorkingMemory()
+        self.episodic_memory = FakeEpisodicMemory()
+
+    def _think(self, observation):
+        return {"tool_name": "demo_tool", "arguments": {"topic": observation["data"]["text_data"]}}
+
+    def _act(self, action):
+        return {"source_tool": action["tool_name"], "data": {"text_data": "ok"}, "is_error": False}
+
+
+def test_main_single_prompt_json_output(monkeypatch, capsys):
+    monkeypatch.setattr("chimera.main.create_agent", lambda **_kwargs: FakeAgent())
+
+    exit_code = main(["--prompt", "demo prompt", "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["action"]["tool_name"] == "demo_tool"
+    assert payload["outcome"]["source_tool"] == "demo_tool"


### PR DESCRIPTION
## What changed
- adds a real `python -m chimera.main` entrypoint for standalone Chimera usage
- keeps the default standalone tool surface small by exposing web search automatically and file-system access only when `--allow-file-system` is passed
- adds focused CLI tests and updates the `agi-project` README with standalone usage examples
- adds a Knight Medicare integration roadmap doc grounded in how KM currently consumes Chimera today

## Why it changed
Knight Medicare currently uses Chimera mostly as a memory and consciousness core behind a FastAPI bridge, while the standalone Chimera package still lacks a supported entrypoint. This PR closes that gap and documents the cleaner adapter direction for future KM integration.

## Impact
- Chimera becomes runnable as a standalone research/demo package without relying on downstream wrappers
- downstream apps get a clearer separation between supported core package surfaces and app-specific orchestration
- the KM integration plan is now documented in the Chimera repo instead of living only in downstream notes

## Validation
- `python3 -m py_compile agi-project/src/chimera/main.py agi-project/tests/test_main.py`
- `PYTHONPATH=src /tmp/project-chimera-venv/bin/python -m pytest -c /dev/null tests/test_main.py tests/test_agent_logic.py tests/test_consciousness.py tests/test_consciousness_simple.py`
- `git diff --check`

## Notes
`agi-project/pyproject.toml` still contains pre-existing merge conflict markers on `master`, so validation was intentionally run with direct Python and pytest commands instead of Poetry-wide commands.