### PR TITLE
feat(eventbus): add Kafka/Redpanda integration for agent traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A modular cognitive architecture for building self-aware AI agents. Chimera comb
 | **RLHF** | Reward model (distilbert) scores candidate responses. Oracle selects the best. Trains on preference data. | $0 (CPU training) |
 | **LLM Backend** | Gemini 1.5 Flash via API (1,500 req/day free tier). Async + sync support. | $0 (free tier) |
 | **Tool Use** | Extensible tool registry with JSON schemas. Built-in: web search, file system. Pluggable: therapy tools, custom tools. | $0 |
+| **Event Bus** | Pluggable Kafka/Redpanda event bus (`chimera.eventbus`). Every perception, action, tool call, memory write, and metacognitive reflection is published as a structured event with a per-cycle `trace_id` for replay. Falls back to `NullEventBus` when no broker is configured. | $0 (Redpanda local) |
 
 **Total infrastructure cost: $0**
 
@@ -64,9 +65,17 @@ src/chimera/
 │   ├── integration.py       #   ConsciousnessIntegration (bridge to agent)
 │   └── conscious_agent.py   #   ConsciousnessAwareAgent (Agent + Narcissus combined)
 │
-└── rlhf/                    # Reinforcement Learning from Human Feedback
-    ├── reward_model.py      #   RewardModel (distilbert fine-tuning via TRL)
-    └── oracle.py            #   RLHFOracle (scores + selects best response)
+├── rlhf/                    # Reinforcement Learning from Human Feedback
+│   ├── reward_model.py      #   RewardModel (distilbert fine-tuning via TRL)
+│   └── oracle.py            #   RLHFOracle (scores + selects best response)
+│
+└── eventbus/                # Durable event bus (Kafka / Redpanda)
+    ├── events.py            #   Event dataclass + topic constants
+    ├── bus.py               #   EventBus ABC, Null + InMemory implementations
+    ├── kafka_bus.py         #   KafkaEventBus (kafka-python)
+    ├── replay.py            #   KafkaTopicConsumer + TraceReplayer
+    ├── config.py            #   EventBusConfig (env-driven)
+    └── factory.py           #   build_event_bus() dispatcher
 ```
 
 ## Quick Start
@@ -247,6 +256,106 @@ python scripts/train_reward_model.py
 
 # 3. Use in agent (see "Run with RLHF" above)
 ```
+
+### Event Bus (Kafka / Redpanda)
+
+Chimera publishes every step of the agent loop as a structured event so
+modules can evolve independently and entire agent traces can be replayed
+for debugging and research.
+
+**Topics**
+
+| Topic | When emitted | Key payload fields |
+|-------|--------------|--------------------|
+| `chimera.perception`        | Each perceive step | `observation` |
+| `chimera.actions`           | After `_think` selects an action | `action`, `num_candidates`, `recalled_count` |
+| `chimera.tool_calls`        | Tool invoke + tool result | `tool_name`, `arguments`, `outcome`, `is_error`, `phase` |
+| `chimera.memory_writes`     | Each episodic memory write | `kind`, `observation`, `action`, `outcome` |
+| `chimera.metacog_reflections` | Narcissus cognitive-state record | `thought_process`, `attention_weights`, `confidence`, `self_reflection` |
+| `chimera.agent_traces`      | Loop start, cycle complete, loop end | `phase`, `tool_name`, `is_error` |
+
+Every event carries:
+
+```json
+{
+  "event_id":   "uuid",
+  "trace_id":   "uuid (shared by all events in one perceive→think→act cycle)",
+  "session_id": "uuid (one per Agent run)",
+  "agent_id":   "string",
+  "event_type": "perception | action_selected | tool_invoke | tool_result | memory_write | cognitive_state | cycle_complete | ...",
+  "timestamp":  1714000000.123,
+  "schema_version": 1,
+  "payload":    { ... topic-specific ... }
+}
+```
+
+`trace_id` is also used as the Kafka partition key, so all events from a
+single agent cycle land on the same partition and stay in order.
+
+**Run a local broker (Redpanda)**
+
+```bash
+cd agi-project
+docker compose up -d            # Redpanda + Console UI on :8080
+export CHIMERA_KAFKA_BROKERS=localhost:9092
+
+# Optional: pre-create topics with 7-day retention
+python scripts/create_kafka_topics.py
+```
+
+**Run the agent against the bus**
+
+```bash
+poetry run python -m chimera.cli \
+    --task "Summarize the latest LLM papers" \
+    --kafka-brokers localhost:9092
+```
+
+Or programmatically:
+
+```python
+from chimera import Agent, build_event_bus, EventBusConfig
+
+bus = build_event_bus(EventBusConfig(bootstrap_servers=["localhost:9092"]))
+agent = Agent(cognitive_core=core, tool_registry=tools,
+              db_path="./chimera_db", event_bus=bus)
+agent.run_main_loop({"task": "..."})
+bus.close()
+```
+
+If `CHIMERA_KAFKA_BROKERS` is unset (or `kafka-python` is not installed),
+`build_event_bus()` returns a `NullEventBus` and Chimera runs unchanged —
+the bus is strictly additive.
+
+**Replay an agent trace**
+
+```python
+from chimera.eventbus import EventBusConfig
+from chimera.eventbus.replay import TraceReplayer
+
+cfg = EventBusConfig(bootstrap_servers=["localhost:9092"])
+replayer = TraceReplayer(cfg)
+
+groups = replayer.group_by_trace(max_events=500)
+for trace_id, events in groups.items():
+    print(f"--- cycle {trace_id} ({len(events)} events) ---")
+    for e in events:
+        print(f"  {e.event_type:20s} {e.topic}")
+```
+
+In tests, swap the bus for `InMemoryEventBus` and assert on
+`bus.history(topic)` — see `tests/test_eventbus.py` for the full pattern.
+
+**Configuration env vars**
+
+| Var | Purpose |
+|-----|---------|
+| `CHIMERA_KAFKA_BROKERS`     | Comma-separated bootstrap servers. Empty = bus disabled. |
+| `CHIMERA_KAFKA_CLIENT_ID`   | Producer client id (default `chimera-agent`). |
+| `CHIMERA_KAFKA_TOPIC_PREFIX`| Optional prefix for topic isolation (e.g. `dev.`). |
+| `CHIMERA_AGENT_ID`          | Stamped onto every event. |
+| `CHIMERA_SESSION_ID`        | Stamped onto every event; auto-generated if unset. |
+| `CHIMERA_EVENTBUS_ENABLED`  | Set to `0` to force `NullEventBus` even when brokers are configured. |
 
 ## Integration: Knight Medicare
 

--- a/agi-project/docker-compose.yml
+++ b/agi-project/docker-compose.yml
@@ -1,0 +1,68 @@
+version: "3.8"
+
+# Local development stack for Project Chimera.
+#
+# Brings up a single-node Redpanda broker (Kafka API compatible) and the
+# Redpanda Console UI. Redpanda is dramatically lighter than the full
+# Kafka + Zookeeper combo and is the recommended option for local dev.
+#
+# Usage:
+#   cd agi-project
+#   docker compose up -d
+#   export CHIMERA_KAFKA_BROKERS=localhost:9092
+#   poetry run python -m chimera.cli --task "..." --kafka-brokers localhost:9092
+#
+# Console UI: http://localhost:8080
+# Kafka API:  localhost:9092
+# Schema reg: localhost:8081
+# Pandaproxy: localhost:8082
+#
+# Topics are auto-created on first publish. To pre-create with sane retention
+# settings see scripts/create_kafka_topics.py.
+
+services:
+  redpanda:
+    image: redpandadata/redpanda:v24.2.7
+    container_name: chimera-redpanda
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9094,external://0.0.0.0:9092
+      - --advertise-kafka-addr internal://redpanda:9094,external://localhost:9092
+      - --pandaproxy-addr internal://0.0.0.0:8083,external://0.0.0.0:8082
+      - --advertise-pandaproxy-addr internal://redpanda:8083,external://localhost:8082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:8081
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    ports:
+      - "9092:9092"     # Kafka API (external)
+      - "8081:8081"     # Schema Registry
+      - "8082:8082"     # Pandaproxy (REST)
+      - "9644:9644"     # Admin API
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health --exit-when-healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  console:
+    image: redpandadata/console:v2.7.2
+    container_name: chimera-redpanda-console
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKERS: redpanda:9094
+      KAFKA_SCHEMAREGISTRY_ENABLED: "true"
+      KAFKA_SCHEMAREGISTRY_URLS: http://redpanda:8081
+    ports:
+      - "8080:8080"
+
+volumes:
+  redpanda-data:
+    driver: local

--- a/agi-project/pyproject.toml
+++ b/agi-project/pyproject.toml
@@ -23,6 +23,8 @@ pyarrow = "~16.1.0"
 datasets = "~2.19.1"
 transformers = "~4.41.2"
 trl = "~0.9.4"
+# Event bus (Kafka / Redpanda) — pure-Python client, no librdkafka.
+kafka-python = "^2.0"
 # Rust FFI libraries will be added here as they are developed
 
 [tool.poetry.group.dev.dependencies]

--- a/agi-project/requirements-submodule.txt
+++ b/agi-project/requirements-submodule.txt
@@ -9,6 +9,10 @@ ddgs>=8.0.0
 fastapi>=0.100.0
 uvicorn>=0.23.0
 
+# Event bus (Kafka / Redpanda). Optional at runtime — Chimera falls back to
+# a NullEventBus when no broker is configured.
+kafka-python>=2.0.0
+
 # Optional RLHF components
 torch>=2.0.0
 transformers>=4.35.0

--- a/agi-project/scripts/create_kafka_topics.py
+++ b/agi-project/scripts/create_kafka_topics.py
@@ -1,0 +1,68 @@
+"""Pre-create the Chimera topics with sane retention defaults.
+
+This is optional — the agent will auto-create topics on first publish — but
+running this once gives you predictable retention and partition counts.
+
+Usage:
+    export CHIMERA_KAFKA_BROKERS=localhost:9092
+    python scripts/create_kafka_topics.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from chimera.eventbus import ALL_TOPICS, EventBusConfig
+
+
+# 7 days of replayable agent traces is plenty for research / debugging.
+DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+DEFAULT_PARTITIONS = 3
+DEFAULT_REPLICATION = 1  # single-node dev cluster
+
+
+def main() -> int:
+    cfg = EventBusConfig.from_env()
+    if not cfg.bootstrap_servers:
+        print(
+            "CHIMERA_KAFKA_BROKERS is not set. Pass it as an env var, e.g.\n"
+            "  CHIMERA_KAFKA_BROKERS=localhost:9092 python scripts/create_kafka_topics.py"
+        )
+        return 1
+
+    try:
+        from kafka.admin import KafkaAdminClient, NewTopic
+        from kafka.errors import TopicAlreadyExistsError
+    except ImportError:
+        print("kafka-python is required. Install with: pip install kafka-python")
+        return 1
+
+    admin = KafkaAdminClient(
+        bootstrap_servers=cfg.bootstrap_servers,
+        client_id="chimera-topic-bootstrap",
+    )
+
+    new_topics = [
+        NewTopic(
+            name=cfg.topic(t),
+            num_partitions=DEFAULT_PARTITIONS,
+            replication_factor=DEFAULT_REPLICATION,
+            topic_configs={"retention.ms": str(DEFAULT_RETENTION_MS)},
+        )
+        for t in ALL_TOPICS
+    ]
+
+    for topic in new_topics:
+        try:
+            admin.create_topics([topic])
+            print(f"created topic: {topic.name}")
+        except TopicAlreadyExistsError:
+            print(f"topic exists:  {topic.name}")
+
+    admin.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agi-project/src/chimera/__init__.py
+++ b/agi-project/src/chimera/__init__.py
@@ -3,9 +3,20 @@ from .agent.agent import Agent
 from .agent.memory import VectorEpisodicMemory, WorkingMemory, Experience
 from .agent.tool_user import ToolRegistry, WebSearchTool, FileSystemTool, Tool
 from .consciousness.conscious_agent import ConsciousnessAwareAgent
+from .consciousness.integration import ConsciousnessIntegration
 from .rlhf.oracle import RLHFOracle
 from .consciousness.narcissus_core import NarcissusConsciousnessCore
 from .cognitive_core.interfaces import CognitiveCore
+from .eventbus import (
+    EventBus,
+    NullEventBus,
+    InMemoryEventBus,
+    EventBusConfig,
+    Event,
+    Topics,
+    build_event_bus,
+)
+
 __all__ = [
     "PrometheusCognitiveCore",
     "Agent",
@@ -17,7 +28,15 @@ __all__ = [
     "FileSystemTool",
     "Tool",
     "ConsciousnessAwareAgent",
+    "ConsciousnessIntegration",
     "RLHFOracle",
     "NarcissusConsciousnessCore",
     "CognitiveCore",
+    "EventBus",
+    "NullEventBus",
+    "InMemoryEventBus",
+    "EventBusConfig",
+    "Event",
+    "Topics",
+    "build_event_bus",
 ]

--- a/agi-project/src/chimera/agent/agent.py
+++ b/agi-project/src/chimera/agent/agent.py
@@ -1,8 +1,10 @@
 
 import json
-from typing import TYPE_CHECKING, Any
+import uuid
+from typing import TYPE_CHECKING, Any, Optional
 
 from ..cognitive_core.interfaces import CognitiveCore
+from ..eventbus import EventBus, NullEventBus, Topics
 from .memory import Experience, VectorEpisodicMemory, WorkingMemory
 from .tool_user import ToolRegistry, WebSearchTool
 
@@ -12,40 +14,74 @@ if TYPE_CHECKING:
 class Agent:
     """The main agent class that orchestrates the AGI's operation."""
 
-    def __init__(self, cognitive_core: CognitiveCore, tool_registry: ToolRegistry, db_path: str, rlhf_oracle: "RLHFOracle" = None, num_candidates: int = 3):
+    def __init__(
+        self,
+        cognitive_core: CognitiveCore,
+        tool_registry: ToolRegistry,
+        db_path: str,
+        rlhf_oracle: "RLHFOracle" = None,
+        num_candidates: int = 3,
+        event_bus: Optional[EventBus] = None,
+        agent_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ):
         self.cognitive_core = cognitive_core
         self.tool_registry = tool_registry
         self.working_memory = WorkingMemory()
         self.episodic_memory = VectorEpisodicMemory(db_path=db_path)
         self.rlhf_oracle = rlhf_oracle
         self.num_candidates = num_candidates
+        self.event_bus: EventBus = event_bus or NullEventBus()
+        self.agent_id = agent_id or "chimera-agent"
+        self.session_id = session_id or str(uuid.uuid4())
         # Ensure WebSearchTool is registered
         if "web_search" not in self.tool_registry.get_tool_names():
             self.tool_registry.register_tool(WebSearchTool())
 
-    def _think(self, observation: Any) -> Any:
+    def _emit(
+        self,
+        topic: str,
+        payload: dict,
+        *,
+        trace_id: str,
+        event_type: Optional[str] = None,
+    ) -> None:
+        """Publish to the event bus, swallowing any errors."""
+        try:
+            self.event_bus.publish(
+                topic,
+                payload,
+                trace_id=trace_id,
+                session_id=self.session_id,
+                agent_id=self.agent_id,
+                event_type=event_type,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"--- event bus publish failed ({topic}): {exc} ---")
+
+    def _think(self, observation: Any, trace_id: str) -> Any:
         """Uses the cognitive core and RLHF oracle to decide on the best next action."""
         # 1. Get context from working memory and relevant memories from episodic memory.
         context = self.working_memory.get_context()
         query_text = json.dumps(observation)
         recalled_memories = self.episodic_memory.recall(query_text)
-        
+
         # 2. Format the prompt for the cognitive core.
         prompt = f"""
         You are an autonomous agent. Here is the current situation:
-        
+
         **Recalled Experiences (from long-term vector memory):**
         {recalled_memories}
 
         **Recent History (from working memory):**
         {context}
-        
+
         **Current Observation:**
         {observation}
-        
+
         **Available Tools:**
         {self.tool_registry.get_tool_schemas()}
-        
+
         Based on the observation, your history, and your recalled experiences, what is your next action?
         Your response must be a JSON object that strictly adheres to the schema of one of the available tools.
         For example:
@@ -57,17 +93,17 @@ class Agent:
             }}
         }}
         """
-        
+
         # 3. Generate multiple candidate actions.
         if self.rlhf_oracle and self.num_candidates > 1:
             print(f"\n--- Generating {self.num_candidates} candidate actions ---")
             candidates = [self.cognitive_core.generate_response({"text_data": prompt}, temperature=0.9) for _ in range(self.num_candidates)]
-            
+
             # 4. Consult the RLHF Oracle to choose the best action.
             print("--- Consulting RLHF Oracle to select best action ---")
             best_action_json = self.rlhf_oracle.get_best_response(prompt, candidates)
             print(f"--- Oracle chose best action: {best_action_json} ---")
-            
+
             # (Future Work): Here, we can implement the automated preference pair generation.
             # The `best_action_json` is the "chosen" response, and a random other candidate
             # can be the "rejected" one. This pair can be saved to preference_data.jsonl
@@ -85,18 +121,47 @@ class Agent:
                 "tool_name": "error_handler",
                 "arguments": {"error_message": "Invalid JSON response from cognitive core or oracle."}
             }
+
+        self._emit(
+            Topics.ACTIONS,
+            {
+                "action": action,
+                "num_candidates": self.num_candidates if self.rlhf_oracle else 1,
+                "recalled_count": len(recalled_memories) if recalled_memories else 0,
+            },
+            trace_id=trace_id,
+            event_type="action_selected",
+        )
         return action
 
-    def _act(self, action: Any) -> Any:
+    def _act(self, action: Any, trace_id: str) -> Any:
         """Executes the chosen action using the tool registry."""
+        tool_name = action.get("tool_name", "unknown_tool")
+        arguments = action.get("arguments", {})
+        self._emit(
+            Topics.TOOL_CALLS,
+            {"tool_name": tool_name, "arguments": arguments, "phase": "invoke"},
+            trace_id=trace_id,
+            event_type="tool_invoke",
+        )
         try:
-            tool_name = action["tool_name"]
-            arguments = action["arguments"]
             tool = self.tool_registry.get_tool(tool_name)
             result = tool(**arguments)
             outcome = {"source_tool": tool.name, "data": {"text_data": result}, "is_error": False}
         except Exception as e:
-            outcome = {"source_tool": action.get("tool_name", "unknown_tool"), "data": {"text_data": str(e)}, "is_error": True}
+            outcome = {"source_tool": tool_name, "data": {"text_data": str(e)}, "is_error": True}
+
+        self._emit(
+            Topics.TOOL_CALLS,
+            {
+                "tool_name": tool_name,
+                "is_error": outcome["is_error"],
+                "phase": "result",
+                "outcome": outcome,
+            },
+            trace_id=trace_id,
+            event_type="tool_result",
+        )
         return outcome
 
     def run_main_loop(self, initial_observation: Any):
@@ -104,20 +169,69 @@ class Agent:
         observation = initial_observation
         self.working_memory.add(observation)
 
-        while True: # The loop runs continuously
-            action = self._think(observation)
-            self.working_memory.add(action)
+        self._emit(
+            Topics.AGENT_TRACES,
+            {"phase": "loop_start", "initial_observation": initial_observation},
+            trace_id=self.session_id,
+            event_type="loop_start",
+        )
 
-            outcome = self._act(action)
-            self.working_memory.add(outcome)
+        try:
+            while True:  # The loop runs continuously
+                trace_id = str(uuid.uuid4())
+                self._emit(
+                    Topics.PERCEPTION,
+                    {"observation": observation},
+                    trace_id=trace_id,
+                    event_type="perception",
+                )
 
-            experience = Experience(observation=observation, action=action, outcome=outcome)
-            self.episodic_memory.remember(experience)
+                action = self._think(observation, trace_id=trace_id)
+                self.working_memory.add(action)
 
-            observation = outcome
+                outcome = self._act(action, trace_id=trace_id)
+                self.working_memory.add(outcome)
 
-            print(f"---Observation: {observation}\nAction: {action}\nOutcome: {outcome}---")
+                experience = Experience(observation=observation, action=action, outcome=outcome)
+                self.episodic_memory.remember(experience)
+                self._emit(
+                    Topics.MEMORY_WRITES,
+                    {
+                        "kind": "episodic",
+                        "observation": observation,
+                        "action": action,
+                        "outcome": outcome,
+                    },
+                    trace_id=trace_id,
+                    event_type="memory_write",
+                )
 
-            if "exit" in action.get("tool_name", ""):
-                print("Exit condition met. Shutting down agent loop.")
-                break
+                self._emit(
+                    Topics.AGENT_TRACES,
+                    {
+                        "phase": "cycle_complete",
+                        "tool_name": action.get("tool_name"),
+                        "is_error": outcome.get("is_error", False),
+                    },
+                    trace_id=trace_id,
+                    event_type="cycle_complete",
+                )
+
+                observation = outcome
+
+                print(f"---Observation: {observation}\nAction: {action}\nOutcome: {outcome}---")
+
+                if "exit" in action.get("tool_name", ""):
+                    print("Exit condition met. Shutting down agent loop.")
+                    break
+        finally:
+            self._emit(
+                Topics.AGENT_TRACES,
+                {"phase": "loop_end"},
+                trace_id=self.session_id,
+                event_type="loop_end",
+            )
+            try:
+                self.event_bus.flush(timeout=5)
+            except Exception:  # pragma: no cover - defensive
+                pass

--- a/agi-project/src/chimera/cli.py
+++ b/agi-project/src/chimera/cli.py
@@ -6,6 +6,7 @@ from .agent.agent import Agent
 from .agent.tool_user import FileSystemTool, ToolRegistry, WebSearchTool
 from .cognitive_core.prometheus_core import PrometheusCognitiveCore
 from .consciousness.conscious_agent import ConsciousnessAwareAgent
+from .eventbus import EventBusConfig, build_event_bus
 
 
 def main():
@@ -13,29 +14,57 @@ def main():
     parser.add_argument("--task", type=str, help="Initial task for the agent")
     parser.add_argument("--conscious", action="store_true", help="Enable consciousness (self-reflection)")
     parser.add_argument("--db-path", type=str, default="./chimera_db", help="Path to the memory database")
-    
+    parser.add_argument(
+        "--kafka-brokers",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated Kafka/Redpanda bootstrap servers (e.g. localhost:9092). "
+            "If omitted the agent uses CHIMERA_KAFKA_BROKERS or runs without an event bus."
+        ),
+    )
+    parser.add_argument("--agent-id", type=str, default=None, help="Agent identifier embedded in events")
+    parser.add_argument("--session-id", type=str, default=None, help="Session identifier embedded in events")
+
     args = parser.parse_args()
-    
+
     if not args.task:
         print("Error: --task is required.")
         parser.print_help()
         sys.exit(1)
-        
+
     # Check for API key
     if "CHIMERA_LLM_API_KEY" not in os.environ:
         print("Warning: CHIMERA_LLM_API_KEY not found in environment. Prometheus core may fail.")
+
+    # Build event bus from env or CLI overrides
+    bus_config = EventBusConfig.from_env()
+    if args.kafka_brokers:
+        bus_config.bootstrap_servers = [b.strip() for b in args.kafka_brokers.split(",") if b.strip()]
+    if args.agent_id:
+        bus_config.agent_id = args.agent_id
+    if args.session_id:
+        bus_config.session_id = args.session_id
+    event_bus = build_event_bus(bus_config)
+    print(
+        f"--- Event bus: {type(event_bus).__name__} "
+        f"(brokers={bus_config.bootstrap_servers or 'none'}) ---"
+    )
 
     core = PrometheusCognitiveCore()
     tools = ToolRegistry()
     tools.register_tool(WebSearchTool())
     tools.register_tool(FileSystemTool())
-    
+
     if args.conscious:
         print("--- Initializing Consciousness-Aware Agent ---")
         agent = ConsciousnessAwareAgent(
             cognitive_core=core,
             tool_registry=tools,
             db_path=args.db_path,
+            event_bus=event_bus,
+            agent_id=bus_config.agent_id,
+            session_id=bus_config.session_id,
         )
         agent.enable_self_reflection()
     else:
@@ -44,13 +73,22 @@ def main():
             cognitive_core=core,
             tool_registry=tools,
             db_path=args.db_path,
+            event_bus=event_bus,
+            agent_id=bus_config.agent_id,
+            session_id=bus_config.session_id,
         )
-        
+
     print(f"--- Starting Agent Loop with Task: {args.task} ---")
     try:
         agent.run_main_loop({"task": args.task})
     except KeyboardInterrupt:
         print("\n--- Agent loop stopped by user ---")
+    finally:
+        try:
+            event_bus.close()
+        except Exception:
+            pass
+
 
 if __name__ == "__main__":
     main()

--- a/agi-project/src/chimera/consciousness/conscious_agent.py
+++ b/agi-project/src/chimera/consciousness/conscious_agent.py
@@ -2,11 +2,13 @@
 Consciousness-aware agent that integrates the Narcissus system with Project Chimera's agent functionality
 """
 import json
-from typing import TYPE_CHECKING, Any, Dict, List
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..agent.memory import Experience, VectorEpisodicMemory, WorkingMemory
 from ..agent.tool_user import ToolRegistry
 from ..cognitive_core.interfaces import CognitiveCore
+from ..eventbus import EventBus, NullEventBus, Topics
 from .integration import ConsciousnessIntegration
 from .narcissus_core import NarcissusConsciousnessCore
 from .emotion import EmotionDetector
@@ -17,14 +19,17 @@ if TYPE_CHECKING:
 
 class ConsciousnessAwareAgent:
     """An agent that incorporates self-awareness and consciousness simulation"""
-    
-    def __init__(self, 
-                 cognitive_core: CognitiveCore, 
-                 tool_registry: ToolRegistry, 
-                 db_path: str, 
-                 rlhf_oracle: "RLHFOracle" = None, 
-                 num_candidates: int = 3):
-        
+
+    def __init__(self,
+                 cognitive_core: CognitiveCore,
+                 tool_registry: ToolRegistry,
+                 db_path: str,
+                 rlhf_oracle: "RLHFOracle" = None,
+                 num_candidates: int = 3,
+                 event_bus: Optional[EventBus] = None,
+                 agent_id: Optional[str] = None,
+                 session_id: Optional[str] = None):
+
         # Initialize the base components
         self.cognitive_core = cognitive_core
         self.tool_registry = tool_registry
@@ -32,20 +37,29 @@ class ConsciousnessAwareAgent:
         self.episodic_memory = VectorEpisodicMemory(db_path=db_path)
         self.rlhf_oracle = rlhf_oracle
         self.num_candidates = num_candidates
-        
+        self.event_bus: EventBus = event_bus or NullEventBus()
+        self.agent_id = agent_id or "chimera-conscious-agent"
+        self.session_id = session_id or str(uuid.uuid4())
+
         # Initialize the consciousness system
         self.consciousness_core = NarcissusConsciousnessCore(
             cognitive_core=cognitive_core,
             memory_db_path=db_path
         )
-        self.consciousness_integration = ConsciousnessIntegration(self.consciousness_core)
+        self.consciousness_integration = ConsciousnessIntegration(
+            self.consciousness_core,
+            event_bus=self.event_bus,
+            agent_id=self.agent_id,
+            session_id=self.session_id,
+        )
         self.emotion_detector = EmotionDetector()
-        
+
         # Consciousness parameters
         self.consciousness_weight = 0.3  # How much consciousness affects decision making
         self.self_reflection_enabled = True
         self.introspection_frequency = 10  # Perform introspection every 10 cycles
         self.cycle_count = 0
+        self._current_trace_id: Optional[str] = None
         
     def _think(self, observation: Any) -> Any:
         """Enhanced thinking process with consciousness awareness"""
@@ -167,7 +181,8 @@ class ConsciousnessAwareAgent:
             confidence=confidence,
             memory_context=memory_context,
             processing_load=processing_load,
-            emotional_state=emotional_state
+            emotional_state=emotional_state,
+            trace_id=self._current_trace_id,
         )
 
     def _act(self, action: Any) -> Any:
@@ -182,34 +197,115 @@ class ConsciousnessAwareAgent:
             outcome = {"source_tool": action.get("tool_name", "unknown_tool"), "data": {"text_data": str(e)}, "is_error": True}
         return outcome
 
+    def _emit(self, topic: str, payload: dict, *, trace_id: str, event_type: Optional[str] = None) -> None:
+        try:
+            self.event_bus.publish(
+                topic,
+                payload,
+                trace_id=trace_id,
+                session_id=self.session_id,
+                agent_id=self.agent_id,
+                event_type=event_type,
+            )
+        except Exception:  # pragma: no cover - defensive
+            pass
+
     def run_main_loop(self, initial_observation: Any):
         """Run the main perceive-think-act loop with consciousness awareness"""
         observation = initial_observation
         self.working_memory.add(observation)
 
         print("Consciousness-aware agent loop started...")
-        
-        while True:  # The loop runs continuously
-            action = self._think(observation)
-            self.working_memory.add(action)
 
-            outcome = self._act(action)
-            self.working_memory.add(outcome)
+        self._emit(
+            Topics.AGENT_TRACES,
+            {"phase": "loop_start", "initial_observation": initial_observation, "conscious": True},
+            trace_id=self.session_id,
+            event_type="loop_start",
+        )
 
-            formatted_experience = Experience(
-                observation=observation,
-                action=action,
-                outcome=outcome
+        try:
+            while True:  # The loop runs continuously
+                trace_id = str(uuid.uuid4())
+                self._current_trace_id = trace_id
+                self._emit(
+                    Topics.PERCEPTION,
+                    {"observation": observation},
+                    trace_id=trace_id,
+                    event_type="perception",
+                )
+
+                action = self._think(observation)
+                self.working_memory.add(action)
+                self._emit(
+                    Topics.ACTIONS,
+                    {"action": action},
+                    trace_id=trace_id,
+                    event_type="action_selected",
+                )
+
+                outcome = self._act(action)
+                self.working_memory.add(outcome)
+                self._emit(
+                    Topics.TOOL_CALLS,
+                    {
+                        "tool_name": action.get("tool_name"),
+                        "is_error": outcome.get("is_error", False),
+                        "outcome": outcome,
+                        "phase": "result",
+                    },
+                    trace_id=trace_id,
+                    event_type="tool_result",
+                )
+
+                formatted_experience = Experience(
+                    observation=observation,
+                    action=action,
+                    outcome=outcome
+                )
+                self.episodic_memory.remember(formatted_experience)
+                self._emit(
+                    Topics.MEMORY_WRITES,
+                    {
+                        "kind": "episodic",
+                        "observation": observation,
+                        "action": action,
+                        "outcome": outcome,
+                    },
+                    trace_id=trace_id,
+                    event_type="memory_write",
+                )
+
+                self._emit(
+                    Topics.AGENT_TRACES,
+                    {
+                        "phase": "cycle_complete",
+                        "tool_name": action.get("tool_name"),
+                        "is_error": outcome.get("is_error", False),
+                    },
+                    trace_id=trace_id,
+                    event_type="cycle_complete",
+                )
+
+                observation = outcome
+
+                print(f"---\nObservation: {str(observation)[:200]}...\nAction: {action}\nOutcome: {str(outcome)[:200]}...\n---")
+
+                if "exit" in action.get("tool_name", ""):
+                    print("Exit condition met. Shutting down agent loop.")
+                    break
+        finally:
+            self._current_trace_id = None
+            self._emit(
+                Topics.AGENT_TRACES,
+                {"phase": "loop_end"},
+                trace_id=self.session_id,
+                event_type="loop_end",
             )
-            self.episodic_memory.remember(formatted_experience)
-
-            observation = outcome
-
-            print(f"---\nObservation: {str(observation)[:200]}...\nAction: {action}\nOutcome: {str(outcome)[:200]}...\n---")
-
-            if "exit" in action.get("tool_name", ""):
-                print("Exit condition met. Shutting down agent loop.")
-                break
+            try:
+                self.event_bus.flush(timeout=5)
+            except Exception:  # pragma: no cover - defensive
+                pass
 
     def enable_self_reflection(self):
         """Enable self-reflection capabilities"""

--- a/agi-project/src/chimera/consciousness/integration.py
+++ b/agi-project/src/chimera/consciousness/integration.py
@@ -1,17 +1,27 @@
 """
 Integration module to connect Narcissus consciousness system with Project Chimera's agent
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from ..eventbus import EventBus, NullEventBus, Topics
 from .narcissus_core import NarcissusConsciousnessCore, CognitiveState
 
 
 class ConsciousnessIntegration:
     """Bridges the consciousness system with the main agent functionality"""
-    
-    def __init__(self, consciousness_core: NarcissusConsciousnessCore):
+
+    def __init__(
+        self,
+        consciousness_core: NarcissusConsciousnessCore,
+        event_bus: Optional[EventBus] = None,
+        agent_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ):
         self.consciousness = consciousness_core
         self.consciousness_enabled = True
+        self.event_bus: EventBus = event_bus or NullEventBus()
+        self.agent_id = agent_id
+        self.session_id = session_id
         
     def enable_consciousness_monitoring(self):
         """Enable the consciousness monitoring system"""
@@ -21,22 +31,23 @@ class ConsciousnessIntegration:
         """Disable the consciousness monitoring system (for performance)"""
         self.consciousness.is_monitoring = False
         
-    def record_cognitive_state_from_agent(self, 
+    def record_cognitive_state_from_agent(self,
                                         thought_process: str,
-                                        attention_weights: Dict[str, float], 
+                                        attention_weights: Dict[str, float],
                                         decision_path: List[str],
                                         confidence: float,
                                         memory_context: List[str],
                                         processing_load: float,
-                                        emotional_state: Dict[str, float] = None):
+                                        emotional_state: Dict[str, float] = None,
+                                        trace_id: Optional[str] = None):
         """Record cognitive state from the agent's perspective"""
         if not self.consciousness_enabled:
             return None
-            
+
         if emotional_state is None:
             emotional_state = {"curiosity": 0.7, "confidence": confidence, "focus": 0.8}
-        
-        return self.consciousness.record_cognitive_state(
+
+        state = self.consciousness.record_cognitive_state(
             thought_process=thought_process,
             attention_weights=attention_weights,
             decision_path=decision_path,
@@ -45,6 +56,28 @@ class ConsciousnessIntegration:
             memory_context=memory_context,
             processing_load=processing_load
         )
+
+        try:
+            self.event_bus.publish(
+                Topics.METACOG_REFLECTIONS,
+                {
+                    "thought_process": thought_process,
+                    "attention_weights": attention_weights,
+                    "decision_path": decision_path,
+                    "confidence": confidence,
+                    "emotional_state": emotional_state,
+                    "processing_load": processing_load,
+                    "self_reflection": getattr(state, "self_reflection", None),
+                },
+                trace_id=trace_id,
+                session_id=self.session_id,
+                agent_id=self.agent_id,
+                event_type="cognitive_state",
+            )
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        return state
     
     def get_consciousness_insights(self) -> Dict[str, Any]:
         """Get insights from the consciousness system for agent decision making"""

--- a/agi-project/src/chimera/eventbus/__init__.py
+++ b/agi-project/src/chimera/eventbus/__init__.py
@@ -1,0 +1,38 @@
+"""
+chimera.eventbus
+================
+
+Durable event bus for Project Chimera. Each stage of the agent loop
+(perception, think, tool call, memory write, metacognitive reflection)
+publishes a structured event so modules can evolve independently and so
+agent traces can be replayed for debugging and research.
+
+The bus is pluggable: use ``KafkaEventBus`` against a real broker (or
+Redpanda) in production / development, ``InMemoryEventBus`` in tests, or
+``NullEventBus`` when events should be silently dropped.
+
+Quick start::
+
+    from chimera.eventbus import build_event_bus, Topics
+
+    bus = build_event_bus()  # reads CHIMERA_KAFKA_* env vars
+    bus.publish(Topics.PERCEPTION, {"task": "hello"}, trace_id="t1")
+    bus.close()
+"""
+
+from .bus import EventBus, InMemoryEventBus, NullEventBus
+from .config import EventBusConfig
+from .events import Event, Topics, ALL_TOPICS, new_event
+from .factory import build_event_bus
+
+__all__ = [
+    "EventBus",
+    "NullEventBus",
+    "InMemoryEventBus",
+    "EventBusConfig",
+    "Event",
+    "Topics",
+    "ALL_TOPICS",
+    "new_event",
+    "build_event_bus",
+]

--- a/agi-project/src/chimera/eventbus/bus.py
+++ b/agi-project/src/chimera/eventbus/bus.py
@@ -1,0 +1,128 @@
+"""Abstract event bus + in-process implementations."""
+
+from __future__ import annotations
+
+import abc
+import threading
+from collections import defaultdict, deque
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from .events import Event, new_event
+
+
+class EventBus(abc.ABC):
+    """Abstract publisher/subscriber bus.
+
+    Implementations only need to support fire-and-forget ``publish``.
+    Consumers (``subscribe``, ``drain``) are optional — the Kafka
+    implementation provides them via the dedicated consumer in
+    :mod:`chimera.eventbus.replay`.
+    """
+
+    @abc.abstractmethod
+    def publish(
+        self,
+        topic: str,
+        payload: Dict[str, Any],
+        *,
+        trace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        key: Optional[str] = None,
+    ) -> Event:
+        """Publish a payload to ``topic`` and return the constructed Event."""
+
+    def flush(self, timeout: Optional[float] = None) -> None:
+        """Block until pending events are delivered. No-op by default."""
+
+    def close(self) -> None:
+        """Release any underlying resources. No-op by default."""
+
+
+class NullEventBus(EventBus):
+    """Drops every event. Used when Kafka is unconfigured."""
+
+    def publish(
+        self,
+        topic: str,
+        payload: Dict[str, Any],
+        *,
+        trace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        key: Optional[str] = None,
+    ) -> Event:
+        return new_event(
+            topic=topic,
+            payload=payload,
+            trace_id=trace_id,
+            session_id=session_id,
+            agent_id=agent_id,
+            event_type=event_type,
+        )
+
+
+Subscriber = Callable[[Event], None]
+
+
+class InMemoryEventBus(EventBus):
+    """Thread-safe in-process bus.
+
+    Useful for tests and for single-process Chimera deployments that want
+    pub/sub semantics without standing up a broker. Events are retained in a
+    bounded per-topic deque so consumers that join late can still drain
+    recent history.
+    """
+
+    def __init__(self, history_per_topic: int = 1000):
+        self._lock = threading.RLock()
+        self._history: Dict[str, deque] = defaultdict(
+            lambda: deque(maxlen=history_per_topic)
+        )
+        self._subscribers: Dict[str, List[Subscriber]] = defaultdict(list)
+
+    def publish(
+        self,
+        topic: str,
+        payload: Dict[str, Any],
+        *,
+        trace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        key: Optional[str] = None,
+    ) -> Event:
+        event = new_event(
+            topic=topic,
+            payload=payload,
+            trace_id=trace_id,
+            session_id=session_id,
+            agent_id=agent_id,
+            event_type=event_type,
+        )
+        with self._lock:
+            self._history[topic].append(event)
+            subs = list(self._subscribers.get(topic, ()))
+        for callback in subs:
+            callback(event)
+        return event
+
+    def subscribe(self, topic: str, callback: Subscriber) -> None:
+        with self._lock:
+            self._subscribers[topic].append(callback)
+
+    def drain(self, topic: str) -> List[Event]:
+        with self._lock:
+            events = list(self._history.get(topic, ()))
+            self._history[topic].clear()
+        return events
+
+    def history(self, topic: str) -> List[Event]:
+        with self._lock:
+            return list(self._history.get(topic, ()))
+
+    def topics(self) -> Iterable[str]:
+        with self._lock:
+            return list(self._history.keys())

--- a/agi-project/src/chimera/eventbus/config.py
+++ b/agi-project/src/chimera/eventbus/config.py
@@ -1,0 +1,53 @@
+"""Configuration for the Chimera event bus."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+def _split_brokers(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    return [b.strip() for b in value.split(",") if b.strip()]
+
+
+@dataclass
+class EventBusConfig:
+    """Event bus configuration.
+
+    ``bootstrap_servers`` is the Kafka / Redpanda broker list. When empty,
+    :func:`chimera.eventbus.build_event_bus` returns a ``NullEventBus`` so
+    Chimera continues to work without a broker.
+    """
+
+    bootstrap_servers: List[str] = field(default_factory=list)
+    client_id: str = "chimera-agent"
+    agent_id: Optional[str] = None
+    session_id: Optional[str] = None
+    topic_prefix: str = ""
+    enabled: bool = True
+    # Producer tuning
+    acks: str = "all"
+    linger_ms: int = 5
+    request_timeout_ms: int = 10_000
+    max_block_ms: int = 5_000
+
+    @classmethod
+    def from_env(cls, env: Optional[dict] = None) -> "EventBusConfig":
+        env = env if env is not None else os.environ
+        enabled_raw = env.get("CHIMERA_EVENTBUS_ENABLED", "1").lower()
+        return cls(
+            bootstrap_servers=_split_brokers(env.get("CHIMERA_KAFKA_BROKERS")),
+            client_id=env.get("CHIMERA_KAFKA_CLIENT_ID", "chimera-agent"),
+            agent_id=env.get("CHIMERA_AGENT_ID"),
+            session_id=env.get("CHIMERA_SESSION_ID"),
+            topic_prefix=env.get("CHIMERA_KAFKA_TOPIC_PREFIX", ""),
+            enabled=enabled_raw not in ("0", "false", "no", ""),
+        )
+
+    def topic(self, name: str) -> str:
+        if self.topic_prefix:
+            return f"{self.topic_prefix}{name}"
+        return name

--- a/agi-project/src/chimera/eventbus/events.py
+++ b/agi-project/src/chimera/eventbus/events.py
@@ -1,0 +1,114 @@
+"""Event types and topic constants for the Chimera event bus."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+
+SCHEMA_VERSION = 1
+
+
+class Topics:
+    """Canonical Kafka topic names. Use these constants — never raw strings."""
+
+    PERCEPTION = "chimera.perception"
+    ACTIONS = "chimera.actions"
+    TOOL_CALLS = "chimera.tool_calls"
+    MEMORY_WRITES = "chimera.memory_writes"
+    METACOG_REFLECTIONS = "chimera.metacog_reflections"
+    AGENT_TRACES = "chimera.agent_traces"
+
+
+ALL_TOPICS = (
+    Topics.PERCEPTION,
+    Topics.ACTIONS,
+    Topics.TOOL_CALLS,
+    Topics.MEMORY_WRITES,
+    Topics.METACOG_REFLECTIONS,
+    Topics.AGENT_TRACES,
+)
+
+
+@dataclass
+class Event:
+    """A single event flowing through the bus.
+
+    ``trace_id`` is shared by all events emitted in one perceive→think→act
+    cycle so a downstream consumer can reconstruct the cycle.
+
+    ``session_id`` groups multiple cycles produced by a single agent run.
+    """
+
+    topic: str
+    payload: Dict[str, Any]
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    trace_id: Optional[str] = None
+    session_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    event_type: Optional[str] = None
+    timestamp: float = field(default_factory=time.time)
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), default=_json_default, sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Event":
+        return cls(
+            topic=data["topic"],
+            payload=data.get("payload", {}),
+            event_id=data.get("event_id", str(uuid.uuid4())),
+            trace_id=data.get("trace_id"),
+            session_id=data.get("session_id"),
+            agent_id=data.get("agent_id"),
+            event_type=data.get("event_type"),
+            timestamp=data.get("timestamp", time.time()),
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> "Event":
+        return cls.from_dict(json.loads(raw))
+
+
+def new_event(
+    topic: str,
+    payload: Dict[str, Any],
+    *,
+    trace_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+) -> Event:
+    """Convenience constructor that fills in event_id and timestamp."""
+    return Event(
+        topic=topic,
+        payload=payload,
+        trace_id=trace_id,
+        session_id=session_id,
+        agent_id=agent_id,
+        event_type=event_type,
+    )
+
+
+def _json_default(obj: Any) -> Any:
+    """Best-effort JSON fallback for non-serializable values in payloads.
+
+    Agent payloads carry arbitrary observations / outcomes from tools, so we
+    coerce unknown types to ``str`` rather than crash the producer.
+    """
+    if hasattr(obj, "to_dict"):
+        try:
+            return obj.to_dict()
+        except Exception:  # pragma: no cover - defensive
+            pass
+    if hasattr(obj, "_asdict"):  # NamedTuple
+        return obj._asdict()
+    return str(obj)

--- a/agi-project/src/chimera/eventbus/factory.py
+++ b/agi-project/src/chimera/eventbus/factory.py
@@ -1,0 +1,50 @@
+"""Factory for selecting the right :class:`EventBus` implementation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .bus import EventBus, NullEventBus
+from .config import EventBusConfig
+
+logger = logging.getLogger(__name__)
+
+
+def build_event_bus(config: Optional[EventBusConfig] = None) -> EventBus:
+    """Return a Kafka-backed bus when configured, else a no-op bus.
+
+    The selection rules are:
+
+    * ``config.enabled`` is False                  → :class:`NullEventBus`
+    * ``config.bootstrap_servers`` is empty        → :class:`NullEventBus`
+    * ``kafka-python`` is not installed            → :class:`NullEventBus`
+    * otherwise                                    → :class:`KafkaEventBus`
+
+    Tests should construct ``InMemoryEventBus`` directly rather than going
+    through this factory.
+    """
+    if config is None:
+        config = EventBusConfig.from_env()
+
+    if not config.enabled:
+        logger.info("EventBus disabled via config; using NullEventBus.")
+        return NullEventBus()
+
+    if not config.bootstrap_servers:
+        logger.info(
+            "No Kafka brokers configured (CHIMERA_KAFKA_BROKERS); "
+            "using NullEventBus."
+        )
+        return NullEventBus()
+
+    try:
+        from .kafka_bus import KafkaEventBus
+    except ImportError as exc:
+        logger.warning(
+            "kafka-python not installed (%s); falling back to NullEventBus.",
+            exc,
+        )
+        return NullEventBus()
+
+    return KafkaEventBus(config)

--- a/agi-project/src/chimera/eventbus/kafka_bus.py
+++ b/agi-project/src/chimera/eventbus/kafka_bus.py
@@ -1,0 +1,112 @@
+"""Kafka-backed implementation of the Chimera event bus.
+
+Uses ``kafka-python`` (pure Python, no librdkafka dependency) so the bus
+works on any platform Chimera already targets. ``confluent-kafka`` could
+be substituted later with no API changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .bus import EventBus
+from .config import EventBusConfig
+from .events import Event, new_event
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaEventBus(EventBus):
+    """Publishes events to a Kafka / Redpanda cluster.
+
+    The producer is created lazily on first ``publish`` so that constructing a
+    bus does not require the broker to be reachable (handy for tests that
+    only assert configuration).
+    """
+
+    def __init__(self, config: EventBusConfig):
+        if not config.bootstrap_servers:
+            raise ValueError(
+                "KafkaEventBus requires at least one bootstrap server. "
+                "Set CHIMERA_KAFKA_BROKERS or pass EventBusConfig(bootstrap_servers=[...])."
+            )
+        self.config = config
+        self._producer = None  # lazy
+
+    def _get_producer(self):
+        if self._producer is not None:
+            return self._producer
+        try:
+            from kafka import KafkaProducer  # type: ignore
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ImportError(
+                "KafkaEventBus requires the 'kafka-python' package. "
+                "Install with: pip install kafka-python"
+            ) from exc
+
+        self._producer = KafkaProducer(
+            bootstrap_servers=self.config.bootstrap_servers,
+            client_id=self.config.client_id,
+            acks=self.config.acks,
+            linger_ms=self.config.linger_ms,
+            request_timeout_ms=self.config.request_timeout_ms,
+            max_block_ms=self.config.max_block_ms,
+            value_serializer=lambda v: v.encode("utf-8"),
+            key_serializer=lambda k: k.encode("utf-8") if k is not None else None,
+        )
+        return self._producer
+
+    def publish(
+        self,
+        topic: str,
+        payload: Dict[str, Any],
+        *,
+        trace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        event_type: Optional[str] = None,
+        key: Optional[str] = None,
+    ) -> Event:
+        event = new_event(
+            topic=topic,
+            payload=payload,
+            trace_id=trace_id,
+            session_id=session_id or self.config.session_id,
+            agent_id=agent_id or self.config.agent_id,
+            event_type=event_type,
+        )
+        full_topic = self.config.topic(topic)
+        # Partition key: prefer trace_id so all events from one cycle land on
+        # the same partition (preserves per-trace ordering for replay).
+        message_key = key or trace_id or event.session_id or event.event_id
+        try:
+            producer = self._get_producer()
+            producer.send(full_topic, key=message_key, value=event.to_json())
+        except Exception as exc:
+            # Kafka failures must not break the agent loop. Log and move on.
+            logger.warning(
+                "KafkaEventBus.publish failed for topic %s: %s", full_topic, exc
+            )
+        return event
+
+    def flush(self, timeout: Optional[float] = None) -> None:
+        if self._producer is None:
+            return
+        try:
+            self._producer.flush(timeout=timeout)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("KafkaEventBus.flush failed: %s", exc)
+
+    def close(self) -> None:
+        if self._producer is None:
+            return
+        try:
+            self._producer.flush(timeout=2)
+        except Exception:  # pragma: no cover - defensive
+            pass
+        try:
+            self._producer.close(timeout=2)
+        except Exception:  # pragma: no cover - defensive
+            pass
+        self._producer = None

--- a/agi-project/src/chimera/eventbus/replay.py
+++ b/agi-project/src/chimera/eventbus/replay.py
@@ -1,0 +1,170 @@
+"""Consume events from Kafka topics — for replay & offline analysis.
+
+Two consumers are provided:
+
+* :class:`KafkaTopicConsumer` — generic blocking iterator over a single topic.
+* :class:`TraceReplayer` — reads ``chimera.agent_traces`` (and optionally
+  related topics) and groups events by ``trace_id`` so a researcher can
+  step through a past agent cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence
+
+from .config import EventBusConfig
+from .events import ALL_TOPICS, Event, Topics
+
+logger = logging.getLogger(__name__)
+
+
+class KafkaTopicConsumer:
+    """Blocking iterator that yields :class:`Event` objects from one or more topics.
+
+    Example::
+
+        cfg = EventBusConfig.from_env()
+        with KafkaTopicConsumer(cfg, [Topics.AGENT_TRACES]) as consumer:
+            for event in consumer:
+                print(event.event_type, event.payload)
+    """
+
+    def __init__(
+        self,
+        config: EventBusConfig,
+        topics: Sequence[str],
+        *,
+        group_id: str = "chimera-replay",
+        auto_offset_reset: str = "earliest",
+        consumer_timeout_ms: Optional[int] = None,
+    ):
+        if not config.bootstrap_servers:
+            raise ValueError("KafkaTopicConsumer requires bootstrap_servers.")
+        self.config = config
+        self._topics = [config.topic(t) for t in topics]
+        self._group_id = group_id
+        self._auto_offset_reset = auto_offset_reset
+        self._consumer_timeout_ms = consumer_timeout_ms
+        self._consumer = None
+
+    def _open(self):
+        if self._consumer is not None:
+            return self._consumer
+        try:
+            from kafka import KafkaConsumer  # type: ignore
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise ImportError(
+                "KafkaTopicConsumer requires 'kafka-python'. "
+                "Install with: pip install kafka-python"
+            ) from exc
+
+        kwargs = dict(
+            bootstrap_servers=self.config.bootstrap_servers,
+            group_id=self._group_id,
+            auto_offset_reset=self._auto_offset_reset,
+            enable_auto_commit=True,
+            value_deserializer=lambda v: v.decode("utf-8"),
+        )
+        if self._consumer_timeout_ms is not None:
+            kwargs["consumer_timeout_ms"] = self._consumer_timeout_ms
+
+        self._consumer = KafkaConsumer(*self._topics, **kwargs)
+        return self._consumer
+
+    def __enter__(self) -> "KafkaTopicConsumer":
+        self._open()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def __iter__(self) -> Iterator[Event]:
+        consumer = self._open()
+        for record in consumer:
+            try:
+                yield Event.from_json(record.value)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to deserialize event from %s: %s",
+                    record.topic,
+                    exc,
+                )
+
+    def close(self) -> None:
+        if self._consumer is None:
+            return
+        try:
+            self._consumer.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+        self._consumer = None
+
+
+class TraceReplayer:
+    """Group events by ``trace_id`` so an agent cycle can be replayed.
+
+    By default it subscribes to *all* Chimera topics. Pass ``topics=[...]``
+    to restrict, or a list including only ``Topics.AGENT_TRACES`` if your
+    agents only emit summary trace events.
+    """
+
+    def __init__(
+        self,
+        config: EventBusConfig,
+        topics: Optional[Sequence[str]] = None,
+        *,
+        group_id: str = "chimera-trace-replay",
+    ):
+        self._consumer = KafkaTopicConsumer(
+            config,
+            topics if topics is not None else list(ALL_TOPICS),
+            group_id=group_id,
+        )
+
+    def stream_traces(
+        self, max_events: Optional[int] = None
+    ) -> Iterator[Event]:
+        """Yield events as they arrive."""
+        with self._consumer as consumer:
+            count = 0
+            for event in consumer:
+                yield event
+                count += 1
+                if max_events is not None and count >= max_events:
+                    break
+
+    def group_by_trace(
+        self, max_events: int
+    ) -> Dict[str, List[Event]]:
+        """Read up to ``max_events`` events and group them by ``trace_id``.
+
+        Events with no ``trace_id`` are bucketed under ``"_untraced"``.
+        Within each bucket events stay in arrival order.
+        """
+        groups: Dict[str, List[Event]] = defaultdict(list)
+        for event in self.stream_traces(max_events=max_events):
+            key = event.trace_id or "_untraced"
+            groups[key].append(event)
+        return dict(groups)
+
+
+def replay_from_iterable(events: Iterable[Event]) -> Dict[str, List[Event]]:
+    """Group an arbitrary iterable of events by trace_id.
+
+    Pure helper, used by tests and the InMemoryEventBus replay path.
+    """
+    groups: Dict[str, List[Event]] = defaultdict(list)
+    for event in events:
+        key = event.trace_id or "_untraced"
+        groups[key].append(event)
+    return dict(groups)
+
+
+__all__ = [
+    "KafkaTopicConsumer",
+    "TraceReplayer",
+    "replay_from_iterable",
+    "Topics",
+]

--- a/agi-project/tests/test_eventbus.py
+++ b/agi-project/tests/test_eventbus.py
@@ -1,0 +1,384 @@
+"""Tests for the Chimera event bus and its integration into the agent loop."""
+
+import json
+from typing import Any, Dict
+
+import pytest
+
+from chimera.eventbus import (
+    Event,
+    EventBusConfig,
+    InMemoryEventBus,
+    NullEventBus,
+    Topics,
+    build_event_bus,
+)
+from chimera.eventbus.events import new_event
+from chimera.eventbus.replay import replay_from_iterable
+
+
+# --- Helpers reused by the agent integration test below -----------------
+
+class FakeSentenceTransformer:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 3
+
+    def encode(self, text: str):
+        length = float(len(text))
+        return [length, length / 2.0, 1.0]
+
+
+class FakeArrow:
+    @staticmethod
+    def schema(fields):
+        return fields
+
+    @staticmethod
+    def field(name, data_type):
+        return (name, data_type)
+
+    @staticmethod
+    def list_(data_type, embedding_dim):
+        return (data_type, embedding_dim)
+
+    @staticmethod
+    def float32():
+        return "float32"
+
+    @staticmethod
+    def string():
+        return "string"
+
+
+class FakeResults:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def iterrows(self):
+        for index, row in enumerate(self.rows):
+            yield index, row
+
+
+class FakeSearch:
+    def __init__(self, rows):
+        self.rows = rows
+        self._limit = len(rows)
+
+    def limit(self, top_k: int):
+        self._limit = top_k
+        return self
+
+    def to_df(self):
+        return FakeResults(self.rows[: self._limit])
+
+
+class FakeTable:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, rows):
+        self.rows.extend(rows)
+
+    def count_rows(self):
+        return len(self.rows)
+
+    def search(self, query_vector):
+        return FakeSearch(self.rows)
+
+
+class FakeDB:
+    def __init__(self):
+        self.tables = {}
+
+    def table_names(self):
+        return list(self.tables.keys())
+
+    def open_table(self, table_name):
+        return self.tables[table_name]
+
+    def create_table(self, table_name, schema):
+        table = FakeTable()
+        self.tables[table_name] = table
+        return table
+
+
+class FakeLanceDB:
+    def __init__(self):
+        self.databases = {}
+
+    def connect(self, path):
+        if path not in self.databases:
+            self.databases[path] = FakeDB()
+        return self.databases[path]
+
+
+# --- Event / serialization tests ----------------------------------------
+
+def test_event_round_trip():
+    event = new_event(
+        topic=Topics.PERCEPTION,
+        payload={"observation": {"task": "hello"}},
+        trace_id="trace-1",
+        session_id="sess-1",
+        agent_id="agent-1",
+        event_type="perception",
+    )
+    raw = event.to_json()
+    restored = Event.from_json(raw)
+
+    assert restored.topic == event.topic
+    assert restored.payload == event.payload
+    assert restored.trace_id == "trace-1"
+    assert restored.session_id == "sess-1"
+    assert restored.agent_id == "agent-1"
+    assert restored.event_type == "perception"
+    assert restored.schema_version == event.schema_version
+
+
+def test_event_serializes_non_json_payload():
+    """Payloads with awkward objects should still round-trip via str fallback."""
+    class Weird:
+        def __repr__(self):
+            return "<weird>"
+
+    event = new_event(topic=Topics.ACTIONS, payload={"obj": Weird()})
+    raw = event.to_json()
+    parsed = json.loads(raw)
+    assert parsed["payload"]["obj"] == "<weird>"
+
+
+# --- Bus implementations ------------------------------------------------
+
+def test_null_bus_returns_event_but_drops_it():
+    bus = NullEventBus()
+    event = bus.publish(Topics.ACTIONS, {"a": 1}, trace_id="t")
+    assert event.topic == Topics.ACTIONS
+    # Null bus has no history / no errors on flush+close
+    bus.flush(timeout=0.1)
+    bus.close()
+
+
+def test_inmemory_bus_records_events_and_notifies_subscribers():
+    bus = InMemoryEventBus()
+    received = []
+    bus.subscribe(Topics.PERCEPTION, received.append)
+
+    bus.publish(Topics.PERCEPTION, {"observation": "x"}, trace_id="t1")
+    bus.publish(Topics.PERCEPTION, {"observation": "y"}, trace_id="t2")
+
+    assert len(received) == 2
+    assert received[0].payload["observation"] == "x"
+    assert received[1].trace_id == "t2"
+
+    history = bus.history(Topics.PERCEPTION)
+    assert [e.payload["observation"] for e in history] == ["x", "y"]
+
+
+def test_inmemory_bus_drain_clears_history():
+    bus = InMemoryEventBus()
+    bus.publish(Topics.AGENT_TRACES, {"phase": "loop_start"}, trace_id="t")
+    drained = bus.drain(Topics.AGENT_TRACES)
+    assert len(drained) == 1
+    assert bus.history(Topics.AGENT_TRACES) == []
+
+
+# --- Factory + config ---------------------------------------------------
+
+def test_build_event_bus_returns_null_when_no_brokers(monkeypatch):
+    cfg = EventBusConfig.from_env(env={})
+    bus = build_event_bus(cfg)
+    assert isinstance(bus, NullEventBus)
+
+
+def test_build_event_bus_returns_null_when_disabled():
+    cfg = EventBusConfig(bootstrap_servers=["localhost:9092"], enabled=False)
+    bus = build_event_bus(cfg)
+    assert isinstance(bus, NullEventBus)
+
+
+def test_event_bus_config_from_env_parses_brokers():
+    env = {
+        "CHIMERA_KAFKA_BROKERS": "broker1:9092,broker2:9092",
+        "CHIMERA_AGENT_ID": "agent-7",
+    }
+    cfg = EventBusConfig.from_env(env=env)
+    assert cfg.bootstrap_servers == ["broker1:9092", "broker2:9092"]
+    assert cfg.agent_id == "agent-7"
+    assert cfg.enabled is True
+
+
+def test_topic_prefix_is_applied():
+    cfg = EventBusConfig(topic_prefix="dev.")
+    assert cfg.topic("chimera.perception") == "dev.chimera.perception"
+
+
+# --- Replay helper ------------------------------------------------------
+
+def test_replay_groups_events_by_trace():
+    e1 = new_event(Topics.PERCEPTION, {"observation": "a"}, trace_id="t1")
+    e2 = new_event(Topics.ACTIONS, {"action": {}}, trace_id="t1")
+    e3 = new_event(Topics.PERCEPTION, {"observation": "b"}, trace_id="t2")
+    e4 = new_event(Topics.ACTIONS, {"action": {}})  # no trace_id
+
+    groups = replay_from_iterable([e1, e2, e3, e4])
+
+    assert set(groups) == {"t1", "t2", "_untraced"}
+    assert [e.topic for e in groups["t1"]] == [Topics.PERCEPTION, Topics.ACTIONS]
+    assert len(groups["t2"]) == 1
+    assert len(groups["_untraced"]) == 1
+
+
+# --- KafkaEventBus configuration guard ----------------------------------
+
+def test_kafka_bus_requires_brokers():
+    from chimera.eventbus.kafka_bus import KafkaEventBus
+
+    with pytest.raises(ValueError):
+        KafkaEventBus(EventBusConfig(bootstrap_servers=[]))
+
+
+# --- Agent loop integration --------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fake_embedding_model(monkeypatch):
+    fake_lancedb = FakeLanceDB()
+    monkeypatch.setattr(
+        "chimera.agent.memory._load_vector_dependencies",
+        lambda: (fake_lancedb, FakeArrow, FakeSentenceTransformer),
+    )
+
+
+@pytest.fixture
+def temp_db_path(tmp_path):
+    return str(tmp_path)
+
+
+def _make_agent(db_path: str, bus: InMemoryEventBus):
+    from chimera import Agent, CognitiveCore, Tool, ToolRegistry
+
+    class ExitTool(Tool):
+        @property
+        def name(self) -> str:
+            return "exit"
+
+        @property
+        def description(self) -> str:
+            return "Stops the agent loop."
+
+        def get_schema(self) -> Dict[str, Any]:
+            return {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {"type": "object", "properties": {}},
+            }
+
+        def __call__(self, **_kwargs) -> str:
+            return "stopping"
+
+    class OneShotCore(CognitiveCore):
+        """Returns a single action that triggers the loop's exit branch."""
+
+        def load_model(self, model_path: str) -> None:
+            pass
+
+        def generate_response(self, inputs, temperature: float = 0.7) -> str:
+            return json.dumps({"tool_name": "exit", "arguments": {}})
+
+        def train(self, dataset) -> None:
+            pass
+
+        def get_state(self):
+            return {}
+
+    registry = ToolRegistry()
+    registry.register_tool(ExitTool())
+    return Agent(
+        cognitive_core=OneShotCore(),
+        tool_registry=registry,
+        db_path=db_path,
+        event_bus=bus,
+        agent_id="test-agent",
+        session_id="test-session",
+    )
+
+
+def test_agent_loop_emits_full_event_sequence(temp_db_path):
+    bus = InMemoryEventBus()
+    agent = _make_agent(temp_db_path, bus)
+
+    agent.run_main_loop({"task": "demo"})
+
+    perceptions = bus.history(Topics.PERCEPTION)
+    actions = bus.history(Topics.ACTIONS)
+    tool_calls = bus.history(Topics.TOOL_CALLS)
+    memory_writes = bus.history(Topics.MEMORY_WRITES)
+    traces = bus.history(Topics.AGENT_TRACES)
+
+    # Exactly one cycle (the exit tool short-circuits the loop).
+    assert len(perceptions) == 1
+    assert len(actions) == 1
+    # tool_calls topic gets both invoke + result events.
+    assert len(tool_calls) == 2
+    assert {e.event_type for e in tool_calls} == {"tool_invoke", "tool_result"}
+    assert len(memory_writes) == 1
+    # AGENT_TRACES contains loop_start, cycle_complete, loop_end.
+    trace_phases = [e.payload.get("phase") for e in traces]
+    assert "loop_start" in trace_phases
+    assert "cycle_complete" in trace_phases
+    assert "loop_end" in trace_phases
+
+    # Per-cycle events all share a single trace_id...
+    cycle_trace_id = perceptions[0].trace_id
+    assert cycle_trace_id is not None
+    for event in (*actions, *tool_calls, *memory_writes):
+        assert event.trace_id == cycle_trace_id
+    # ...and all events carry the agent + session identity.
+    for event in (*perceptions, *actions, *tool_calls, *memory_writes, *traces):
+        assert event.agent_id == "test-agent"
+        assert event.session_id == "test-session"
+
+
+def test_agent_works_with_null_bus_default(temp_db_path):
+    """Agent must run even when no bus is provided (NullEventBus default)."""
+    from chimera import Agent, CognitiveCore, Tool, ToolRegistry
+
+    class ExitTool(Tool):
+        @property
+        def name(self) -> str:
+            return "exit"
+
+        @property
+        def description(self) -> str:
+            return "Stops the agent loop."
+
+        def get_schema(self) -> Dict[str, Any]:
+            return {"name": self.name, "description": self.description,
+                    "parameters": {"type": "object", "properties": {}}}
+
+        def __call__(self, **_kwargs) -> str:
+            return "stopping"
+
+    class OneShotCore(CognitiveCore):
+        def load_model(self, model_path: str) -> None: pass
+
+        def generate_response(self, inputs, temperature: float = 0.7) -> str:
+            return json.dumps({"tool_name": "exit", "arguments": {}})
+
+        def train(self, dataset) -> None: pass
+
+        def get_state(self): return {}
+
+    registry = ToolRegistry()
+    registry.register_tool(ExitTool())
+    agent = Agent(
+        cognitive_core=OneShotCore(),
+        tool_registry=registry,
+        db_path=temp_db_path,
+    )
+
+    # Should complete without raising.
+    agent.run_main_loop({"task": "demo"})
+    assert isinstance(agent.event_bus, NullEventBus)


### PR DESCRIPTION
Introduces chimera.eventbus, a durable event bus that publishes every
stage of the perceive→think→act loop. Modules can now evolve
independently (consume only what they care about), and full agent
cycles can be replayed for debugging and research.

Topics:
  chimera.perception          observations entering the agent
  chimera.actions             actions selected by _think
  chimera.tool_calls          tool invoke + tool result events
  chimera.memory_writes       episodic memory writes
  chimera.metacog_reflections Narcissus cognitive-state records
  chimera.agent_traces        loop start / cycle complete / loop end

Every event carries event_id, trace_id (shared across one cycle),
session_id, agent_id, event_type, timestamp, schema_version, and a
topic-specific payload. trace_id is also the Kafka partition key so
per-cycle ordering is preserved.

Implementation:
  - Pluggable EventBus with NullEventBus, InMemoryEventBus, and
    KafkaEventBus (kafka-python, no librdkafka dependency).
  - build_event_bus() returns NullEventBus when no broker is configured
    or kafka-python is missing — the bus is strictly additive.
  - Wired end-to-end into Agent and ConsciousnessAwareAgent; the
    Narcissus integration emits metacog_reflections with the per-cycle
    trace_id.
  - KafkaTopicConsumer + TraceReplayer for offline replay.
  - docker-compose.yml brings up Redpanda + Console for local dev.
  - scripts/create_kafka_topics.py pre-creates topics with 7-day
    retention.
  - 13 new tests covering serialization round-trips, all three bus
    implementations, the factory dispatch, replay grouping, and a full
    in-memory agent-loop integration that asserts the exact event
    sequence and shared trace_id.

Configured via env vars: CHIMERA_KAFKA_BROKERS, CHIMERA_AGENT_ID,
CHIMERA_SESSION_ID, CHIMERA_KAFKA_TOPIC_PREFIX, CHIMERA_EVENTBUS_ENABLED,
or via the new --kafka-brokers CLI flag.

https://claude.ai/code/session_016aY2vATkPfq7a9S8NcD7aP