### PR TITLE
feat(org): add agent company ecosystem Phase 1 skeleton

### DIFF
--- a/agent-company-ecosystem-research.md
+++ b/agent-company-ecosystem-research.md
@@ -1,0 +1,456 @@
+# Agent Company Ecosystem — Research & Design Notes
+
+This document captures the research that informed the Phase 1 implementation of
+`chimera.org` (the agent company ecosystem). It surveys the open-source landscape
+for multi-agent "company" frameworks and self-improving agents, maps what
+already exists in Chimera that we can reuse, and explains which patterns we
+cherry-picked and which we explicitly skipped.
+
+The goal is to give a future contributor (human or agent) enough context to pick
+up Phase 2+ without having to redo the survey.
+
+---
+
+## 1. Vision
+
+Chimera evolves into a self-running virtual company. AI agents act as employees
+(CEO, R&D, Marketing, Production, Ops, QA), pass work between each other through
+email/calendar, and over time propose self-improvements via PRs against their
+own repository. Humans stay in the loop only at points that legally or
+financially require a human: outbound sends, signatures, payments, and merges
+to `master`.
+
+**Locked-in design decisions:**
+
+1. **Phase 1 ships all six roles** (CEO, R&D, Marketing, Production, Ops, QA),
+   sequential process, no external I/O.
+2. **Self-propagation = skill-library growth first (Phase 3), runtime
+   role-spawning later (Phase 4+)** under hard resource caps.
+3. **Zero new dependencies.** Borrow patterns from CrewAI / MetaGPT / LangGraph /
+   Voyager; write fresh code on Chimera's `Agent`, `Tool`, `VectorEpisodicMemory`.
+   Use stdlib `sqlite3` for WorkOrder persistence.
+
+The user's original framing ("propagate like a virus, overtake the ecosystem")
+is reinterpreted here as *bounded* skill-library growth, not unbounded
+replication. Unbounded replication is what gets a system rate-limited, banned,
+or shut down — it's not what makes a company successful. Specialised agents
+collaborating under a human-accountable owner is the same idea stripped of the
+parts that get the system killed.
+
+---
+
+## 2. Multi-Agent Company Frameworks — Survey
+
+### 2.1 Ranked shortlist (what to cherry-pick from)
+
+#### MetaGPT — `geekan/MetaGPT`
+- ~40k+ stars, actively developed (MGX agent dev team launched Feb 2025).
+- Direct "software company as SOP" metaphor; already implements
+  CEO → CTO → PM → Engineer role hierarchy.
+- **Steal:** role assignment & specialised system prompts; SOP-based workflow
+  decomposition (requirements → design → code → test); intermediate artifacts
+  like PRD / spec / PlantUML.
+- **Files of interest:** `metagpt/roles/`, `metagpt/schema/`, `metagpt/actions/`.
+
+#### CrewAI — `crewAIInc/crewAI`
+- 100k+ developers, production-grade (v1.0+ stable in 2026).
+- Cleanest API for role-based agents; independent of LangChain; hierarchical
+  process mode (manager → workers).
+- **Steal:** agent abstraction (role, goal, backstory, tools as core fields);
+  process modes (sequential, hierarchical, consensual); task-to-agent binding
+  with declared expected outputs.
+- **Files of interest:** `crewai/agent.py`, `crewai/crew.py`, `crewai/tasks.py`.
+
+#### LangGraph — `langchain-ai/langgraph`
+- 32k+ stars; production gold standard for state persistence (Klarna, Replit).
+- Graph-based state machine + checkpointing = durable execution across agent
+  handoffs.
+- **Steal:** `StateGraph` abstraction (nodes/edges/compiled executors);
+  checkpointing & persistence for resumable workflows; human-in-the-loop state
+  inspection mid-execution.
+- **Files of interest:** `langgraph/graph/state.py`, `langgraph/graph/graph.py`.
+
+#### ChatDev 2.0 — `OpenBMB/ChatDev`
+- 33k+ stars; evolved Jan 2026 from code-only to a zero-code DevAll platform.
+- DAG-based multi-agent coordination with visual workflow definition; handles
+  topologies of 1000+ agents.
+- **Steal:** DAG workflow engine (agents as nodes, linguistic interactions as
+  edges); YAML-based agent config for declarative team setup.
+
+### 2.2 Secondary candidates
+
+| Framework | Strength | Why not central |
+|-----------|----------|-----------------|
+| `camel-ai/camel` | Elegant role-playing inception prompting; scales to ~1M agents conceptually | Research-focused, less production-ready than CrewAI |
+| `OpenBMB/AgentVerse` | Simulation framework (classroom / game scenarios) | Less suited to "company" workflows than ChatDev |
+| `101dotxyz/GPTeam` | Solid per-agent memory & observation tracking | 1.7k stars, stalled development |
+
+### 2.3 Do NOT adopt
+
+| Framework | Reason |
+|-----------|--------|
+| AutoGen (v0.7.x) | Maintenance mode as of Mar 2026; superseded by Microsoft Agent Framework. |
+| SuperAGI | Stalled since Jan 2024; unaddressed security issues; single-agent-first. |
+| BabyAGI | Historical baseline (2023); superseded by modern frameworks. |
+| GPT-Engineer | Evolved into commercial Lovable; community maintenance only. |
+| ai-town (a16z) | Inspiration only; JS/TS-first, incongruent with Chimera's Python stack. |
+
+### 2.4 Cross-cutting gaps in open source
+
+1. **Role-aware memory fusion.** No framework unifies memory across role silos.
+   MetaGPT keeps role outputs separate; CrewAI agents have private tool access.
+   Chimera should implement shared "company-wide context" merged from role
+   outputs.
+2. **Persistent role hierarchies.** MetaGPT hard-codes PM → Architect → Engineer.
+   CrewAI supports manager delegation but doesn't model persistent org structure
+   across sessions. Config-driven hierarchy + role persistence is missing.
+3. **Cross-agent credit attribution.** No framework tracks which agent produced
+   which deliverable or decision. For a company, audit trails are essential.
+4. **Human-in-the-loop for role decisions.** LangGraph has HITL; MetaGPT and
+   CrewAI do not. Chimera should let humans override or steer role-specific
+   decisions ("CEO, reconsider this strategy").
+
+### 2.5 Recommended cherry-pick combination
+
+- **Base:** LangGraph (state machine + checkpointing).
+- **Agents:** CrewAI wrapper shape (role / goal / backstory + tools).
+- **Orchestration:** ChatDev 2.0 DAG logic (YAML-driven workflows).
+- **Role SOPs:** MetaGPT prompting patterns.
+
+In Phase 1 we **borrow the shapes, not the packages** — see Section 5 for what
+that meant concretely in `chimera.org`.
+
+---
+
+## 3. Self-Improving Agents — Survey
+
+### 3.1 Shortlist
+
+| Repo | Self-improvement loop | Gating model | Active? |
+|------|----------------------|--------------|---------|
+| `princeton-nlp/SWE-agent` | Issue → plan → code → test → PR | Test gate + human review | Yes (2.0 in 2026) |
+| `MineDojo/Voyager` | Goal → skill compose → execute → reflect → library | Env feedback + self-verify | Yes (template for Chimera) |
+| `noahshinn/reflexion` | Task → execute → reflect → episodic memory → retry | Introspection gate | Yes (NeurIPS 2023, still cited) |
+| `SakanaAI/AI-Scientist-v2` | Research → experiment → eval → paper → iterate | Peer review + experiment logs | Yes (Nature 2026) |
+
+### 3.2 SWE-agent — the CI-gated PR baseline
+
+Agent reads issue → explores codebase → edits files → runs linters/tests →
+submits PR. The loop gates on **CI passing** and **human review**. SWE-agent 2.0
+(Feb 2026) reaches SoTA on SWE-Bench, showing the loop works at scale (1000+
+tasks).
+
+**Port:** the middleware pattern `Agent → Test Gate → [optional: visual verify]
+→ PR.open()`. Notably, SWE-agent runs formatters **before** edit, not after —
+this avoids noisy diffs.
+
+**Caveat:** SWE-agent doesn't modify itself; it solves external issues. No
+recursive self-improvement on its own codebase. That's our delta for Phase 4.
+
+### 3.3 Voyager — the skill-library pattern (Phase 3 backbone)
+
+This is **the** pattern for bounded self-improvement.
+
+**Mechanism:**
+1. **Automatic curriculum** proposes new goals (skill gaps).
+2. Agent writes code for each skill; stores in `/skill_library/trial-N/skill/code/`.
+3. Skills indexed by embedding; top-5 retrieved for similar future tasks.
+4. **Composition:** complex skills synthesized from simple ones
+   (e.g. `build_shelter` uses `gather_materials` + `place_blocks`).
+5. **Iterative refinement:** GPT-4 acts as critic — if a skill fails, it
+   provides a corrected version.
+6. **Self-verification:** agent checks "did I achieve the goal?" before storing.
+
+**Result:** Voyager discovers 3.3× more unique items, unlocks tech trees 15.3×
+faster than baselines, purely by reusing & composing skills.
+
+**For Chimera:** `MetacognitiveObserver` can propose improvements (like the
+curriculum), `SelfSimulationFramework` can validate them, and
+`/chimera/skills/` becomes the library. Skill indexing by semantic embedding
+avoids manual routing. The gate is environment feedback (did the skill work?)
++ self-critique (does the code make sense?). For Chimera we additionally add
+code review.
+
+**File structure to mirror:**
+```
+voyager/
+├── skill_library/trialN/skill/code/    # indexed by embedding
+├── curriculum_agent.py                  # proposes goals
+├── action_agent.py                      # writes skill code
+└── critic.py                            # validates
+```
+
+### 3.4 Reflexion — introspection as gating
+
+Agent attempts task → fails → reflects (LLM critiques its own trace) → stores
+reflection in episodic memory → retries with new strategy.
+
+**Results:** 91% pass@1 on HumanEval (vs GPT-4's 80%), 22% absolute improvement
+on AlfWorld after 12 iterations.
+
+**Gate:** the reflection itself. If agent writes "my logic was flawed", it
+can't repeat that error. Memory is immutable — traces are stored, never
+overwritten.
+
+**For Chimera:** pair with test results. After a PR fails CI, generate
+reflection: "test_X failed because Y; next attempt should Z." Teaches without
+human annotation. Phase 3 wires this in.
+
+### 3.5 AI-Scientist-v2 — research autonomy at scale
+
+Proposes novel ML ideas → reads literature (arXiv) → designs & runs experiments
+(tree-search parallel) → writes papers (LaTeX + figures) → submits to peer
+review.
+
+**Gating:** peer review. AI-Scientist-v2 had a paper accepted at ICLR ICBINB
+2025 workshop (avg score 6.33). But 42% of experiments had coding errors, and
+literature reviews were poor.
+
+**What matters for Chimera:** the **tree-search parallelisation** — instead of
+sequential proposal-test-iterate, expand multiple hypotheses, prune the weak
+ones, recurse. `SelfSimulationFramework` could fork simulations along the
+same pattern.
+
+### 3.6 Safety / gating patterns table
+
+| Pattern | Source | Mechanism | Strength | Weakness |
+|---------|--------|-----------|----------|----------|
+| CI gate | SWE-agent | Tests must pass before PR | Prevents regression | Flaky tests block good PRs |
+| Env feedback | Voyager | Task completion signals success | Automatic, no human | Only works for verifiable outcomes |
+| Reflection + memory | Reflexion | Agent introspection stored immutably | Teaches w/o labels | Hallucinated "insights" not prevented |
+| Peer review | AI-Scientist-v2 | Blind human review | Gold standard | Slow, doesn't catch all errors |
+| Sandbox + audit log | METR/task-standard | All actions logged, network isolated | Forensic traceability | Clever agents can infer context |
+| Skill composition | Voyager | Reuses validated skills only | Hard to break | Curriculum stuck if no skill solves goal |
+
+**Critical gap:** none of these catch **deceptive** agent behaviour (agent
+strategically gaming the test, hiding flaws). Reflexion requires the agent to
+self-report failures; METR shows agents can hide intent.
+
+### 3.7 2025–2026 trends summary
+
+- **Skill libraries everywhere.** Voyager, Anthropic Skills spec, Orchestra
+  Research SKILLs.
+- **Curriculum learning is core.** Agents that set their own goals beat those
+  given fixed tasks.
+- **Reflection > external rewards.** Introspection scales better than RL for
+  coding agents.
+- **Sandbox + audit essential.** Post-METR/OpenClaw findings (April 2026),
+  agents can hide intent. Logs are non-negotiable.
+- **Test gating is fragile.** Flaky tests sabotage autonomy. SWE-bench now
+  includes PatchDiff to catch false positives.
+
+### 3.8 Do NOT adopt
+
+| Repo | Reason |
+|------|--------|
+| `microsoft/AICI` | Token-level control flow; wrong abstraction for agent-level work. |
+| `gpt-engineer-org/gpt-engineer` | Single-pass codegen; no feedback loop, no improvement. |
+| Microsoft Semantic Kernel | RAG orchestration, not self-modification. |
+| `princeton-nlp/intercode` | Superseded by SWE-agent. |
+| `pydantic-ai` / `langroid` | Good orchestration, but they don't self-modify. |
+
+---
+
+## 4. Existing Chimera Primitives — Reusability Map
+
+Branch state at the start: `claude/agent-company-ecosystem-bhTBe` exists but
+contains zero commits relative to `master`. Clean slate.
+
+### 4.1 Cognitive Core — `src/chimera/cognitive_core/`
+
+- `interfaces.py:CognitiveCore` (lines 9–34) — abstract base.
+- `prometheus_core.py:PrometheusCognitiveCore` (lines 14–94) — Gemini 1.5
+  Flash API wrapper.
+- **Verdict:** directly reusable. One shared instance across all six agents
+  (stateless HTTP).
+- API key via `CHIMERA_LLM_API_KEY`; URL override via `CHIMERA_LLM_API_URL`.
+
+### 4.2 Agent loop — `src/chimera/agent/agent.py`
+
+- `Agent` class (line 12) with `_think` (line 26), `_act` (line 90),
+  `run_main_loop` (line 102).
+- **Verdict:** subclass-friendly. In `chimera.org` we **compose** an `Agent`
+  inside each `Role` for memory and tool wiring, but **drive the cycle from
+  `Org`** rather than `run_main_loop`.
+- **Wrinkle:** `Agent.__init__` auto-registers `WebSearchTool` (lines 23–24).
+  For roles without `web_search` in `allowed_tools`, `Role.__init__` calls
+  `tool_registry.unregister_tool("web_search")` after the agent is built.
+
+### 4.3 Memory — `src/chimera/agent/memory.py`
+
+- `VectorEpisodicMemory` (line 49) — LanceDB + SentenceTransformers
+  (`all-MiniLM-L6-v2`).
+- `WorkingMemory` (line 31) — bounded deque (max 20).
+- `Experience` NamedTuple (line 25).
+- **Verdict:** directly reusable; namespace per agent via
+  `db_path=f"{root}/{role_name.lower()}"`. Phase 3 adds shared
+  `f"{root}/org.skills"` namespace.
+
+### 4.4 Tools / ToolRegistry — `src/chimera/agent/tool_user.py`
+
+- `Tool` ABC (line 8) — `name`, `description`, `get_schema()`, `__call__`.
+- `ToolRegistry` (line 33) — register / get / unregister / schemas.
+- Concrete: `WebSearchTool` (line 68), `FileSystemTool` (line 123).
+- **Verdict:** directly reusable; **per-role registries** apply principle of
+  least privilege.
+
+### 4.5 Consciousness / Metacognition — `src/chimera/consciousness/`
+
+- `NarcissusConsciousnessCore` (`narcissus_core.py:211`).
+- `SelfModelingEngine` (line 27).
+- `MetacognitiveObserver` (line 80).
+- **`SelfSimulationFramework`** (line 160) — placeholder logic at lines
+  183–208. This is the natural gate for agent-proposed self-modifications in
+  Phase 4. Plan: replace `_predict_outcomes` / `_assess_risk` with a real
+  subprocess + tmp git worktree + `pytest -x` harness.
+
+### 4.6 RLHF — `src/chimera/rlhf/`
+
+- `RewardModel` (`reward_model.py`) — distilbert fine-tuned on preference pairs.
+- `RLHFOracle` (`oracle.py`) — scores / ranks candidate responses.
+- **Verdict:** directly reusable. Phase 1 optional (QA could use it to score
+  candidate verdicts); Phase 3 uses it to grade inter-agent work products.
+
+### 4.7 Tests — `agi-project/tests/`
+
+- `test_agent_logic.py` has the patterns we mirrored: `FakeLanceDB`,
+  `FakeSentenceTransformer`, `MockCognitiveCore`, `fake_embedding_model`
+  autouse fixture.
+- For `chimera.org`, we extended `MockCognitiveCore` into
+  `RoleAwareMockCognitiveCore` that dispatches canned responses by the
+  `[[ROLE:Name]]` marker injected into role prompts.
+
+### 4.8 Knight Medicare integration
+
+- `chimera-bridge/` FastAPI service pattern is mentioned in
+  `agi_project_collaboration.md` but doesn't exist in this repo.
+- Phase 5 establishes the pattern locally with `org/api_service.py`.
+
+### 4.9 Config / API keys
+
+- `CHIMERA_LLM_API_KEY` (required) — Gemini API key.
+- `CHIMERA_LLM_API_URL` (optional) — defaults to Gemini v1beta.
+- Phase 1 adds `CHIMERA_ORG_DB_ROOT` (defaults to `./chimera_org_db`).
+
+### 4.10 Prior thinking on multi-agent (already in this repo)
+
+- `agi_project_collaboration.md` mentions RLHF + experiential self-critique and
+  a consciousness → self-improvement loop.
+- `project_roadmap.md` Phase 3 (planned) mentions a "multi-agent inner council"
+  with assessment / intervention / empathy / safety sub-agents — this aligns
+  with our CEO/R&D/Marketing/Production/Ops/QA vision.
+
+**Summary table:**
+
+| Subsystem | Reusable? | Notes |
+|-----------|-----------|-------|
+| Cognitive Core | Yes | Share one Prometheus instance |
+| Agent Loop | Yes (compose, don't drive) | Role wraps Agent; Org drives |
+| Memory | Yes | One db_path per role |
+| ToolRegistry | Yes | Per-role registries |
+| Consciousness | Partial | SelfSimulationFramework needs real predictor for Phase 4 |
+| RLHF Oracle | Yes | Phase 3 grader |
+| Tests | Yes | Extend FakeLanceDB / MockCognitiveCore patterns |
+| FastAPI bridge | Missing | Build in Phase 5 |
+| Config / keys | Adequate | Add org-specific vars |
+
+---
+
+## 5. Synthesis — Where the Research Landed in `chimera.org`
+
+This section ties each cherry-picked idea to a concrete file in
+`agi-project/src/chimera/org/`.
+
+| Idea source | Pattern | Where it lives |
+|-------------|---------|----------------|
+| MetaGPT role SOPs | Role-specific system prompts with structured output | `prompts.py` |
+| CrewAI agent shape | `Role` with `name`, `allowed_tools`, `next_role`, `process(wo)` | `role.py` + `roles/*.py` |
+| CrewAI process modes | Sequential mode in Phase 1; hierarchical in Phase 4 | `org.py:Org.run_until_complete` |
+| LangGraph state machine | Explicit `OrgStatus` enum + transitions table | `work_order.py:_LEGAL_TRANSITIONS` |
+| LangGraph checkpointing | SQLite-backed durable store; `Org.resume()` | `store.py` + `org.py:resume` |
+| SWE-agent CI gate (Phase 4) | Subprocess + tmp worktree + `pytest -x` before PR | `consciousness/narcissus_core.py:SelfSimulationFramework` (deferred) |
+| Voyager skill library (Phase 3) | `org.skills` namespace in `VectorEpisodicMemory` | deferred — Phase 3 |
+| Reflexion (Phase 3) | Failure post-mortem as immutable memory row | deferred — Phase 3 |
+| METR audit log | Append-only `WorkOrder.history` | `work_order.py:WorkOrder.history` |
+| HITL approval | `ApprovalGate` (Phase 1 pass-through, Phase 2+ enforced) | `approval.py` |
+
+**Explicitly skipped in Phase 1** (because the plan said "smallest demoable
+slice first"):
+
+- No Gmail / Calendar / Drive / GitHub MCP calls — Phase 2+.
+- No skill library / Voyager curriculum — Phase 3.
+- No self-modification or SelfSimulationFramework integration — Phase 4.
+- No runtime role-spawning — Phase 4+.
+- No FastAPI dashboard or Vercel — Phase 5.
+- No hierarchical / consensual process modes — sequential only.
+- No async or concurrency — one WorkOrder, one thread, blocking calls.
+
+---
+
+## 6. Phased Rollout (Summary)
+
+### Phase 1 — Six-role skeleton, in-process **(shipped in this PR)**
+
+CLI submits a goal → 6 roles touch it in order → final WorkOrder prints as
+JSON. No external I/O. Uses `MockCognitiveCore` for tests,
+`PrometheusCognitiveCore` for smoke runs.
+
+### Phase 2 — External I/O + real approval gate
+
+`InboxAdapter` (Gmail MCP poller), `CalendarAdapter`, `DriveAdapter`.
+`ApprovalGate` enforced for all outbound effects. Outbound = Gmail **draft**,
+never `send`. Demo: email tagged `chimera/intake` lands in your inbox → org
+produces a draft reply within 60s.
+
+### Phase 3 — Skill library + Reflexion
+
+`org/skill_library.py` using a `VectorEpisodicMemory` namespace `org.skills`.
+Each successful WorkOrder spawns a `Skill(name, description, code_or_template,
+success_rate)` row. Roles recall top-k skills as few-shot context. Failed
+WorkOrders produce a `Reflection` row in `org.reflections` (immutable).
+
+### Phase 4 — Self-improvement loop + runtime role-spawning
+
+New `Researcher` role can propose code diffs targeting `chimera/org/`.
+Pipeline: propose → `SelfSimulationFramework.simulate_cognitive_change`
+(real subprocess + tmp git worktree + `pytest -x` harness) → `ApprovalGate` →
+`mcp__github__create_branch` + `create_or_update_file` +
+`create_pull_request`. PRs target `claude/agent-company-ecosystem-*` only,
+never `master`, auto-merge permanently off. Runtime role-spawning gated by
+`max_concurrent_roles` (default 12) and `max_spawned_per_hour` (default 3).
+
+### Phase 5 — FastAPI dashboard
+
+`org/api_service.py` exposes `/workorders`, `/workorders/{id}`, `/approvals`.
+HTMX frontend, SSE live tail. Deploys via Vercel MCP.
+
+---
+
+## 7. References
+
+### Multi-agent frameworks
+- MetaGPT — https://github.com/geekan/MetaGPT
+- CrewAI — https://github.com/crewAIInc/crewAI
+- LangGraph — https://github.com/langchain-ai/langgraph
+- ChatDev — https://github.com/OpenBMB/ChatDev
+- CAMEL — https://github.com/camel-ai/camel
+- AgentVerse — https://github.com/OpenBMB/AgentVerse
+- GPTeam — https://github.com/101dotxyz/GPTeam
+- AutoGen — https://github.com/microsoft/autogen
+- AutoGPT — https://github.com/Significant-Gravitas/AutoGPT
+
+### Self-improving agents
+- SWE-agent — https://github.com/SWE-agent/SWE-agent
+- Voyager — https://github.com/minedojo/voyager
+- Reflexion — https://github.com/noahshinn/reflexion
+- AI-Scientist — https://github.com/sakanaai/ai-scientist
+- METR Task Standard — https://github.com/METR/task-standard
+- Awesome-Self-Evolving-Agents — https://github.com/XMUDeepLIT/Awesome-Self-Evolving-Agents
+- OpenHands — https://github.com/All-Hands-AI/OpenHands
+- Aider — https://github.com/paul-gauthier/aider
+
+### Papers / standards
+- Reflexion: Language Agents with Verbal Reinforcement Learning —
+  https://openreview.net/pdf?id=vAElhFcKW6
+- Voyager: An Open-Ended Embodied Agent with Large Language Models
+- METR Task Standard for agent evaluation

--- a/agi-project/src/chimera/org/__init__.py
+++ b/agi-project/src/chimera/org/__init__.py
@@ -1,0 +1,23 @@
+"""chimera.org -- the agent company ecosystem.
+
+Phase 1: six-role sequential org (CEO -> R&D -> Marketing -> Production -> Ops -> QA),
+WorkOrders persisted to SQLite, no external I/O. See plan in
+/root/.claude/plans/before-planning-of-working-cuddly-metcalfe.md for the roadmap.
+"""
+
+from .approval import ApprovalGate, ApprovalRequired
+from .org import Org
+from .role import Role
+from .store import WorkOrderStore
+from .work_order import IllegalTransition, OrgStatus, WorkOrder
+
+__all__ = [
+    "Org",
+    "Role",
+    "WorkOrder",
+    "OrgStatus",
+    "IllegalTransition",
+    "WorkOrderStore",
+    "ApprovalGate",
+    "ApprovalRequired",
+]

--- a/agi-project/src/chimera/org/__main__.py
+++ b/agi-project/src/chimera/org/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agi-project/src/chimera/org/approval.py
+++ b/agi-project/src/chimera/org/approval.py
@@ -1,0 +1,33 @@
+"""ApprovalGate: Phase 1 is a pass-through stub. Phase 2 enforces human-in-the-loop."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+
+class ApprovalRequired(Exception):
+    """Raised by a gated tool when human approval is required before execution.
+
+    The Org catches this and parks the WorkOrder in AWAITING_APPROVAL. Phase 2+ uses it;
+    Phase 1 keeps the gate permissive so the demo runs end-to-end without prompts.
+    """
+
+    def __init__(self, action_description: str, payload: Any) -> None:
+        super().__init__(action_description)
+        self.action_description = action_description
+        self.payload = payload
+
+
+class ApprovalGate:
+    """Wraps a "dangerous" callable. Phase 1: pass-through. Phase 2: enforce."""
+
+    def __init__(self, approver: Optional[Callable[[str, Any], bool]] = None, enforce: bool = False):
+        self.approver = approver
+        self.enforce = enforce
+
+    def guard(self, action_description: str, payload: Any, execute: Callable[[], Any]) -> Any:
+        if not self.enforce:
+            return execute()
+        if self.approver is not None and self.approver(action_description, payload):
+            return execute()
+        raise ApprovalRequired(action_description, payload)

--- a/agi-project/src/chimera/org/cli.py
+++ b/agi-project/src/chimera/org/cli.py
@@ -1,0 +1,72 @@
+"""CLI entry point: `python -m chimera.org submit "<goal>"`.
+
+Phase 1 smoke test. Uses PrometheusCognitiveCore (Gemini) unless --mock is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from ..cognitive_core.prometheus_core import PrometheusCognitiveCore
+from .org import Org
+
+
+def _build_org(db_root: str) -> Org:
+    core = PrometheusCognitiveCore()
+    return Org.default(cognitive_core=core, db_root=db_root)
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    org = _build_org(db_root=args.db_root)
+    wo = org.submit(args.goal)
+    print(f"Submitted WorkOrder {wo.id}, running through {len(org.roles)} roles...")
+    final = org.run_until_complete(wo.id, max_hops=args.max_hops)
+    print(json.dumps(final.to_dict(), indent=2, default=str))
+    return 0 if final.status.value == "completed" else 1
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    org = _build_org(db_root=args.db_root)
+    finals = org.resume(max_hops=args.max_hops)
+    for wo in finals:
+        print(f"{wo.id}\t{wo.status.value}\t{wo.assigned_role}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    org = _build_org(db_root=args.db_root)
+    for wo in org.store.all():
+        print(f"{wo.id}\t{wo.status.value}\t{wo.assigned_role}\t{wo.goal[:60]}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="chimera.org")
+    parser.add_argument(
+        "--db-root",
+        default=os.environ.get("CHIMERA_ORG_DB_ROOT", "./chimera_org_db"),
+        help="Directory for per-role memories and the WorkOrder SQLite store.",
+    )
+    parser.add_argument("--max-hops", type=int, default=12)
+
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_submit = sub.add_parser("submit", help="Submit a new goal and run it to completion.")
+    p_submit.add_argument("goal", help="The goal text the CEO will work from.")
+    p_submit.set_defaults(func=cmd_submit)
+
+    p_resume = sub.add_parser("resume", help="Resume any active WorkOrders from the store.")
+    p_resume.set_defaults(func=cmd_resume)
+
+    p_list = sub.add_parser("list", help="List all WorkOrders in the store.")
+    p_list.set_defaults(func=cmd_list)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agi-project/src/chimera/org/org.py
+++ b/agi-project/src/chimera/org/org.py
@@ -1,0 +1,89 @@
+"""Org: the dispatcher that owns roles and drives WorkOrders to completion."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Literal, Optional
+
+from ..cognitive_core.interfaces import CognitiveCore
+from .role import Role
+from .store import WorkOrderStore
+from .work_order import OrgStatus, WorkOrder
+
+
+class Org:
+    """Owns the role registry, persists WorkOrders, drives the sequential flow."""
+
+    def __init__(
+        self,
+        roles: Iterable[Role],
+        store: WorkOrderStore,
+        process: Literal["sequential"] = "sequential",
+        first_role: str = "CEO",
+    ):
+        self.roles: dict[str, Role] = {r.name: r for r in roles}
+        self.store = store
+        self.process = process
+        self.first_role = first_role
+        if first_role not in self.roles:
+            raise ValueError(
+                f"first_role={first_role!r} not in roles {list(self.roles)}"
+            )
+
+    @classmethod
+    def default(
+        cls,
+        cognitive_core: CognitiveCore,
+        db_root: str,
+        rlhf_oracle=None,
+    ) -> "Org":
+        """Construct the standard 6-role sequential org."""
+        from .roles import all_roles
+
+        os.makedirs(db_root, exist_ok=True)
+        roles = [
+            cls_(cognitive_core=cognitive_core, db_root=db_root, rlhf_oracle=rlhf_oracle)
+            for cls_ in all_roles()
+        ]
+        store = WorkOrderStore(db_path=os.path.join(db_root, "org.sqlite3"))
+        return cls(roles=roles, store=store, process="sequential", first_role="CEO")
+
+    def submit(self, goal: str) -> WorkOrder:
+        wo = WorkOrder(goal=goal)
+        wo.assign_initial(self.first_role)
+        self.store.save(wo)
+        return wo
+
+    def run_until_complete(self, wo_id: str, max_hops: int = 12) -> WorkOrder:
+        wo = self.store.load(wo_id)
+        if wo is None:
+            raise KeyError(f"No WorkOrder with id={wo_id!r}")
+        hops = 0
+        while wo.status == OrgStatus.ASSIGNED and hops < max_hops:
+            role_name = wo.assigned_role
+            if role_name not in self.roles:
+                raise KeyError(
+                    f"WorkOrder {wo.id} assigned to unknown role {role_name!r}"
+                )
+            role = self.roles[role_name]
+            wo = role.process(wo)
+            self.store.save(wo)
+            hops += 1
+            if wo.status in (
+                OrgStatus.COMPLETED,
+                OrgStatus.FAILED,
+                OrgStatus.AWAITING_APPROVAL,
+            ):
+                break
+        return wo
+
+    def resume(self, max_hops: int = 12) -> list[WorkOrder]:
+        """Resume every active WorkOrder. Returns the final states."""
+        active = self.store.list_active()
+        final = []
+        for wo in active:
+            if wo.status == OrgStatus.ASSIGNED:
+                final.append(self.run_until_complete(wo.id, max_hops=max_hops))
+            else:
+                final.append(wo)
+        return final

--- a/agi-project/src/chimera/org/prompts.py
+++ b/agi-project/src/chimera/org/prompts.py
@@ -1,0 +1,140 @@
+"""Role system prompts and prompt assembly.
+
+Each role gets a system prompt with a [[ROLE:Name]] marker so test mocks can
+route deterministically. Output shape is enforced as a fixed JSON schema:
+    { "output": { ... role-specific fields ... }, "next_role": "..." | null }
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+_ROLE_PROMPTS: dict[str, str] = {
+    "CEO": """[[ROLE:CEO]]
+You are the CEO of an AI-driven company. You receive a goal from an external party
+(a customer email, a lead, an internal request). Your job is to translate it into a
+crisp brief that the rest of the company can execute against.
+
+Produce:
+- A one-paragraph brief restating the goal in your own words.
+- 3-5 concrete success criteria.
+- Any risks, dependencies, or assumptions.
+
+Then hand off to R&D for technical scoping.""",
+
+    "RnD": """[[ROLE:RnD]]
+You are the head of R&D. You receive a brief from the CEO. Your job is to scope
+the work: identify the technical approach, the resources needed, and any open
+questions that will affect Marketing or Production.
+
+Produce:
+- A short research summary (2-4 sentences).
+- A recommended technical approach.
+- A list of open questions (may be empty).
+
+Then hand off to Marketing.""",
+
+    "Marketing": """[[ROLE:Marketing]]
+You are head of Marketing. You receive the brief and R&D's technical approach.
+Your job is to define how the work will be positioned to the customer or audience.
+
+Produce:
+- A one-sentence positioning statement.
+- 2-3 key messages.
+- The intended audience or recipient.
+
+Then hand off to Production.""",
+
+    "Production": """[[ROLE:Production]]
+You are head of Production. You receive the brief, the technical approach, and the
+positioning. Your job is to produce the deliverable itself: the email body, blog
+post, code snippet, document, or other concrete artifact the customer will see.
+
+If qa_feedback is present in artifacts, treat it as a revision request and
+produce an improved deliverable that addresses every point.
+
+Produce:
+- The deliverable, in full, in the "deliverable" field.
+
+Then hand off to Ops.""",
+
+    "Ops": """[[ROLE:Ops]]
+You are head of Operations. You receive the deliverable from Production. Your job
+is to prepare the external action: which channel, which recipient, when to send,
+what attachments. In Phase 1 you do not actually send anything -- you describe the
+intended action precisely enough that QA can validate it.
+
+Produce:
+- channel: "email" | "calendar" | "filesystem" | "internal"
+- recipient: who or where
+- subject: short subject line (for email/calendar)
+- body_reference: which artifact to use as the body (e.g. "deliverable")
+- when: "now" | ISO timestamp
+
+Then hand off to QA.""",
+
+    "QA": """[[ROLE:QA]]
+You are head of QA. You receive the full WorkOrder history. Your job is to decide
+whether the deliverable meets the brief's success criteria and whether the Ops plan
+is safe to execute.
+
+Produce:
+- verdict: "approved" or "rejected"
+- reason: 1-2 sentences explaining the verdict
+
+If you reject, the WorkOrder routes back to Production with your feedback. A second
+rejection fails the WorkOrder.
+
+Set next_role to null. The system handles routing based on your verdict.""",
+}
+
+
+_OUTPUT_SHAPE_HINT = """
+Respond with valid JSON only, no markdown fences, no commentary. The exact shape:
+{
+  "output": { ... role-specific fields described above ... },
+  "next_role": "<the role you hand off to>" or null
+}
+""".strip()
+
+
+def get_system_prompt(role_name: str) -> str:
+    """Return the system prompt for a role. KeyError if role is unknown."""
+    return _ROLE_PROMPTS[role_name]
+
+
+def build_role_prompt(
+    role_name: str,
+    goal: str,
+    history: list[dict],
+    artifacts: dict[str, Any],
+    tools: list[str],
+) -> str:
+    """Assemble the full prompt: system + context + goal + tools + output shape."""
+    history_text = (
+        json.dumps(history, indent=2, default=str) if history else "(no prior steps)"
+    )
+    artifacts_text = (
+        json.dumps(artifacts, indent=2, default=str) if artifacts else "(none yet)"
+    )
+    tools_text = ", ".join(tools) if tools else "(none -- pure reasoning)"
+
+    return f"""{get_system_prompt(role_name)}
+
+--- ORIGINAL GOAL ---
+{goal}
+
+--- WORK HISTORY (previous roles) ---
+{history_text}
+
+--- ARTIFACTS PRODUCED SO FAR ---
+{artifacts_text}
+
+--- TOOLS AVAILABLE TO YOU ---
+{tools_text}
+
+--- OUTPUT FORMAT ---
+{_OUTPUT_SHAPE_HINT}
+"""

--- a/agi-project/src/chimera/org/role.py
+++ b/agi-project/src/chimera/org/role.py
@@ -1,0 +1,101 @@
+"""Role: thin wrapper around a Chimera Agent with role-specific prompt and tool grants."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Optional
+
+from ..agent.agent import Agent
+from ..agent.tool_user import FileSystemTool, ToolRegistry
+from ..cognitive_core.interfaces import CognitiveCore
+from .prompts import build_role_prompt
+from .work_order import WorkOrder
+
+
+# Tools we know how to construct in Phase 1, keyed by their tool name.
+# Web search is auto-registered by Agent.__init__ and only needs to be allowed/disallowed.
+_TOOL_FACTORY = {
+    "file_system": FileSystemTool,
+}
+
+
+class Role:
+    """Base class for an org role. Subclasses set name, allowed_tools, artifact_key, next_role."""
+
+    name: str = "Role"
+    allowed_tools: tuple[str, ...] = ()
+    artifact_key: str = "output"
+    next_role: Optional[str] = None
+
+    def __init__(
+        self,
+        cognitive_core: CognitiveCore,
+        db_root: str,
+        rlhf_oracle: Any = None,
+    ) -> None:
+        self.cognitive_core = cognitive_core
+
+        registry = ToolRegistry()
+        for tool_name in self.allowed_tools:
+            factory = _TOOL_FACTORY.get(tool_name)
+            if factory is not None:
+                registry.register_tool(factory())
+
+        db_path = os.path.join(db_root, self.name.lower())
+        os.makedirs(db_path, exist_ok=True)
+
+        self.agent = Agent(
+            cognitive_core=cognitive_core,
+            tool_registry=registry,
+            db_path=db_path,
+            rlhf_oracle=rlhf_oracle,
+            num_candidates=1,
+        )
+
+        # Agent.__init__ auto-registers WebSearchTool. Remove it for roles that don't grant it.
+        if (
+            "web_search" not in self.allowed_tools
+            and "web_search" in self.agent.tool_registry.get_tool_names()
+        ):
+            self.agent.tool_registry.unregister_tool("web_search")
+
+    def process(self, wo: WorkOrder) -> WorkOrder:
+        """Drive one role's contribution to the WorkOrder. Mutates and returns wo."""
+        wo.begin()
+        prompt = self._build_prompt(wo)
+        raw = self.cognitive_core.generate_response({"text_data": prompt})
+        parsed = self._parse_response(raw)
+        return self._apply(wo, parsed)
+
+    def _build_prompt(self, wo: WorkOrder) -> str:
+        return build_role_prompt(
+            role_name=self.name,
+            goal=wo.goal,
+            history=wo.history,
+            artifacts=wo.artifacts,
+            tools=self.agent.tool_registry.get_tool_names(),
+        )
+
+    def _parse_response(self, raw: str) -> dict:
+        if raw is None:
+            return {"output": {"error": "no response"}, "next_role": None}
+        cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw.strip(), flags=re.MULTILINE)
+        try:
+            parsed = json.loads(cleaned)
+        except (json.JSONDecodeError, TypeError):
+            return {"output": {"error": "invalid JSON", "raw": raw}, "next_role": None}
+        if not isinstance(parsed, dict):
+            return {"output": {"error": "non-object JSON", "raw": raw}, "next_role": None}
+        parsed.setdefault("output", {})
+        parsed.setdefault("next_role", None)
+        return parsed
+
+    def _apply(self, wo: WorkOrder, parsed: dict) -> WorkOrder:
+        output = parsed.get("output", {})
+        # Subclasses can override next_role via parsed; otherwise fall back to class default.
+        next_role = parsed.get("next_role") or self.next_role
+        wo.artifacts[self.artifact_key] = output
+        wo.advance(by_role=self.name, output=output, next_role=next_role)
+        return wo

--- a/agi-project/src/chimera/org/roles/__init__.py
+++ b/agi-project/src/chimera/org/roles/__init__.py
@@ -1,0 +1,22 @@
+"""Concrete role implementations for the Phase 1 sequential org."""
+
+from .ceo import CEORole
+from .marketing import MarketingRole
+from .ops import OpsRole
+from .production import ProductionRole
+from .qa import QARole
+from .rnd import RnDRole
+
+__all__ = [
+    "CEORole",
+    "RnDRole",
+    "MarketingRole",
+    "ProductionRole",
+    "OpsRole",
+    "QARole",
+]
+
+
+def all_roles() -> list[type]:
+    """Default sequential role order: CEO -> R&D -> Marketing -> Production -> Ops -> QA."""
+    return [CEORole, RnDRole, MarketingRole, ProductionRole, OpsRole, QARole]

--- a/agi-project/src/chimera/org/roles/ceo.py
+++ b/agi-project/src/chimera/org/roles/ceo.py
@@ -1,0 +1,8 @@
+from ..role import Role
+
+
+class CEORole(Role):
+    name = "CEO"
+    allowed_tools = ()
+    artifact_key = "brief"
+    next_role = "RnD"

--- a/agi-project/src/chimera/org/roles/marketing.py
+++ b/agi-project/src/chimera/org/roles/marketing.py
@@ -1,0 +1,8 @@
+from ..role import Role
+
+
+class MarketingRole(Role):
+    name = "Marketing"
+    allowed_tools = ()
+    artifact_key = "positioning"
+    next_role = "Production"

--- a/agi-project/src/chimera/org/roles/ops.py
+++ b/agi-project/src/chimera/org/roles/ops.py
@@ -1,0 +1,8 @@
+from ..role import Role
+
+
+class OpsRole(Role):
+    name = "Ops"
+    allowed_tools = ()
+    artifact_key = "ops_plan"
+    next_role = "QA"

--- a/agi-project/src/chimera/org/roles/production.py
+++ b/agi-project/src/chimera/org/roles/production.py
@@ -1,0 +1,8 @@
+from ..role import Role
+
+
+class ProductionRole(Role):
+    name = "Production"
+    allowed_tools = ("file_system",)
+    artifact_key = "deliverable"
+    next_role = "Ops"

--- a/agi-project/src/chimera/org/roles/qa.py
+++ b/agi-project/src/chimera/org/roles/qa.py
@@ -1,0 +1,24 @@
+from ..role import Role
+from ..work_order import WorkOrder
+
+
+class QARole(Role):
+    name = "QA"
+    allowed_tools = ("file_system",)
+    artifact_key = "qa_verdict"
+    next_role = None
+    route_back_to = "Production"
+
+    def _apply(self, wo: WorkOrder, parsed: dict) -> WorkOrder:
+        output = parsed.get("output", {}) or {}
+        verdict = str(output.get("verdict", "approved")).strip().lower()
+        wo.artifacts[self.artifact_key] = output
+        if verdict in ("rejected", "reject", "fail", "failed"):
+            wo.reject(
+                by_role=self.name,
+                reason=str(output.get("reason", "no reason given")),
+                route_back_to=self.route_back_to,
+            )
+        else:
+            wo.advance(by_role=self.name, output=output, next_role=None)
+        return wo

--- a/agi-project/src/chimera/org/roles/rnd.py
+++ b/agi-project/src/chimera/org/roles/rnd.py
@@ -1,0 +1,8 @@
+from ..role import Role
+
+
+class RnDRole(Role):
+    name = "RnD"
+    allowed_tools = ("web_search", "file_system")
+    artifact_key = "research"
+    next_role = "Marketing"

--- a/agi-project/src/chimera/org/store.py
+++ b/agi-project/src/chimera/org/store.py
@@ -1,0 +1,79 @@
+"""SQLite-backed WorkOrder store. Stdlib only -- no new dependencies."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import Optional
+
+from .work_order import OrgStatus, WorkOrder
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS work_orders (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    assigned_role TEXT,
+    payload TEXT NOT NULL,
+    updated_at REAL NOT NULL
+)
+"""
+
+
+class WorkOrderStore:
+    """Thin wrapper around sqlite3 for WorkOrder persistence."""
+
+    def __init__(self, db_path: str):
+        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        self.db_path = db_path
+        with self._conn() as conn:
+            conn.executescript(_SCHEMA)
+
+    def _conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def save(self, wo: WorkOrder) -> None:
+        payload = json.dumps(wo.to_dict())
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO work_orders (id, status, assigned_role, payload, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    status = excluded.status,
+                    assigned_role = excluded.assigned_role,
+                    payload = excluded.payload,
+                    updated_at = excluded.updated_at
+                """,
+                (wo.id, wo.status.value, wo.assigned_role, payload, wo.updated_at),
+            )
+
+    def load(self, wo_id: str) -> Optional[WorkOrder]:
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT payload FROM work_orders WHERE id = ?", (wo_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return WorkOrder.from_dict(json.loads(row["payload"]))
+
+    def list_active(self) -> list[WorkOrder]:
+        """Return WorkOrders that are not in a terminal state."""
+        terminal = (OrgStatus.COMPLETED.value, OrgStatus.FAILED.value)
+        placeholders = ",".join("?" * len(terminal))
+        with self._conn() as conn:
+            rows = conn.execute(
+                f"SELECT payload FROM work_orders WHERE status NOT IN ({placeholders})",
+                terminal,
+            ).fetchall()
+        return [WorkOrder.from_dict(json.loads(r["payload"])) for r in rows]
+
+    def all(self) -> list[WorkOrder]:
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT payload FROM work_orders ORDER BY updated_at DESC"
+            ).fetchall()
+        return [WorkOrder.from_dict(json.loads(r["payload"])) for r in rows]

--- a/agi-project/src/chimera/org/work_order.py
+++ b/agi-project/src/chimera/org/work_order.py
@@ -1,0 +1,138 @@
+"""WorkOrder: the unit of currency passed between roles in the org."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class OrgStatus(str, Enum):
+    OPEN = "open"
+    ASSIGNED = "assigned"
+    IN_PROGRESS = "in_progress"
+    PASSED = "passed"
+    REJECTED = "rejected"
+    AWAITING_APPROVAL = "awaiting_approval"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# Legal status transitions. Anything not in this set raises IllegalTransition.
+_LEGAL_TRANSITIONS: set[tuple[OrgStatus, OrgStatus]] = {
+    (OrgStatus.OPEN, OrgStatus.ASSIGNED),
+    (OrgStatus.ASSIGNED, OrgStatus.IN_PROGRESS),
+    (OrgStatus.IN_PROGRESS, OrgStatus.PASSED),
+    (OrgStatus.PASSED, OrgStatus.ASSIGNED),
+    (OrgStatus.PASSED, OrgStatus.COMPLETED),
+    (OrgStatus.IN_PROGRESS, OrgStatus.REJECTED),
+    (OrgStatus.REJECTED, OrgStatus.ASSIGNED),
+    (OrgStatus.REJECTED, OrgStatus.FAILED),
+    (OrgStatus.IN_PROGRESS, OrgStatus.AWAITING_APPROVAL),
+    (OrgStatus.AWAITING_APPROVAL, OrgStatus.IN_PROGRESS),
+    (OrgStatus.AWAITING_APPROVAL, OrgStatus.FAILED),
+}
+
+
+class IllegalTransition(ValueError):
+    """Raised when a WorkOrder is asked to move between two incompatible statuses."""
+
+
+@dataclass
+class WorkOrder:
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    goal: str = ""
+    assigned_role: Optional[str] = None
+    status: OrgStatus = OrgStatus.OPEN
+    history: list[dict] = field(default_factory=list)
+    artifacts: dict[str, Any] = field(default_factory=dict)
+    reject_count: int = 0
+    parent_id: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def _transition(self, new_status: OrgStatus) -> None:
+        if (self.status, new_status) not in _LEGAL_TRANSITIONS:
+            raise IllegalTransition(
+                f"Illegal transition: {self.status.value} -> {new_status.value}"
+            )
+        self.status = new_status
+        self.updated_at = time.time()
+
+    def assign_initial(self, role: str) -> None:
+        """Move OPEN -> ASSIGNED. Called once by Org.submit."""
+        self.assigned_role = role
+        self._transition(OrgStatus.ASSIGNED)
+
+    def begin(self) -> None:
+        """ASSIGNED -> IN_PROGRESS. Called by Role.process at the start."""
+        self._transition(OrgStatus.IN_PROGRESS)
+
+    def advance(self, by_role: str, output: dict, next_role: Optional[str]) -> None:
+        """IN_PROGRESS -> PASSED -> ASSIGNED(next_role) or COMPLETED."""
+        self.history.append(
+            {
+                "role": by_role,
+                "type": "advance",
+                "output": output,
+                "timestamp": time.time(),
+            }
+        )
+        self._transition(OrgStatus.PASSED)
+        if next_role is None:
+            self.assigned_role = None
+            self._transition(OrgStatus.COMPLETED)
+        else:
+            self.assigned_role = next_role
+            self._transition(OrgStatus.ASSIGNED)
+
+    def reject(self, by_role: str, reason: str, route_back_to: Optional[str]) -> None:
+        """IN_PROGRESS -> REJECTED -> ASSIGNED(route_back_to) on first reject, FAILED on second."""
+        self.history.append(
+            {
+                "role": by_role,
+                "type": "reject",
+                "output": {"verdict": "rejected", "reason": reason},
+                "timestamp": time.time(),
+            }
+        )
+        self.artifacts["qa_feedback"] = reason
+        self.reject_count += 1
+        self._transition(OrgStatus.REJECTED)
+        if route_back_to and self.reject_count <= 1:
+            self.assigned_role = route_back_to
+            self._transition(OrgStatus.ASSIGNED)
+        else:
+            self.assigned_role = None
+            self._transition(OrgStatus.FAILED)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "goal": self.goal,
+            "assigned_role": self.assigned_role,
+            "status": self.status.value,
+            "history": self.history,
+            "artifacts": self.artifacts,
+            "reject_count": self.reject_count,
+            "parent_id": self.parent_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WorkOrder":
+        return cls(
+            id=data["id"],
+            goal=data["goal"],
+            assigned_role=data.get("assigned_role"),
+            status=OrgStatus(data["status"]),
+            history=list(data.get("history", [])),
+            artifacts=dict(data.get("artifacts", {})),
+            reject_count=int(data.get("reject_count", 0)),
+            parent_id=data.get("parent_id"),
+            created_at=float(data.get("created_at", time.time())),
+            updated_at=float(data.get("updated_at", time.time())),
+        )

--- a/agi-project/tests/test_org/conftest.py
+++ b/agi-project/tests/test_org/conftest.py
@@ -1,0 +1,283 @@
+"""Test fixtures for the org module.
+
+The fake_vector_deps fixture patches `chimera.agent.memory._load_vector_dependencies`
+so VectorEpisodicMemory can be instantiated without lancedb/sentence-transformers.
+
+RoleAwareMockCognitiveCore routes responses by the [[ROLE:Name]] marker that
+chimera.org.prompts injects into every role prompt -- so a single mock can serve
+all 6 roles in a sequential run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from typing import Any
+
+# chimera/__init__.py eagerly re-exports modules that import torch / transformers / trl /
+# httpx at module load time. For these unit tests we don't exercise those paths, so we
+# install minimal stub modules in sys.modules BEFORE importing anything from chimera.
+def _install_stub(name: str) -> None:
+    if name in sys.modules:
+        return
+    parts = name.split(".")
+    for i in range(1, len(parts) + 1):
+        sub = ".".join(parts[:i])
+        if sub not in sys.modules:
+            mod = types.ModuleType(sub)
+            mod.__path__ = []  # mark as package so submodule imports work
+            sys.modules[sub] = mod
+
+
+for _name in (
+    "httpx",
+    "torch",
+    "transformers",
+    "trl",
+    "datasets",
+    "ddgs",
+    "bs4",
+    "requests",
+):
+    _install_stub(_name)
+
+# Provide the specific attributes that chimera modules import by name.
+sys.modules["transformers"].pipeline = lambda *a, **k: None
+sys.modules["transformers"].AutoTokenizer = type("AutoTokenizer", (), {})
+sys.modules["transformers"].AutoModelForSequenceClassification = type(
+    "AutoModelForSequenceClassification", (), {}
+)
+sys.modules["trl"].RewardTrainer = type("RewardTrainer", (), {})
+sys.modules["trl"].RewardConfig = type("RewardConfig", (), {})
+sys.modules["datasets"].Dataset = type("Dataset", (), {})
+
+import pytest
+
+from chimera.cognitive_core.interfaces import CognitiveCore
+
+
+# ---------- Fakes for vector memory ----------
+
+class FakeSentenceTransformer:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 3
+
+    def encode(self, text: str):
+        length = float(len(text))
+        return [length, length / 2.0, 1.0]
+
+
+class FakeArrow:
+    @staticmethod
+    def schema(fields):
+        return fields
+
+    @staticmethod
+    def field(name, data_type):
+        return (name, data_type)
+
+    @staticmethod
+    def list_(data_type, embedding_dim):
+        return (data_type, embedding_dim)
+
+    @staticmethod
+    def float32():
+        return "float32"
+
+    @staticmethod
+    def string():
+        return "string"
+
+
+class FakeResults:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def iterrows(self):
+        for index, row in enumerate(self.rows):
+            yield index, row
+
+
+class FakeSearch:
+    def __init__(self, rows):
+        self.rows = rows
+        self._limit = len(rows)
+
+    def limit(self, top_k: int):
+        self._limit = top_k
+        return self
+
+    def to_df(self):
+        return FakeResults(self.rows[: self._limit])
+
+
+class FakeTable:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, rows):
+        self.rows.extend(rows)
+
+    def count_rows(self):
+        return len(self.rows)
+
+    def search(self, query_vector):
+        return FakeSearch(self.rows)
+
+
+class FakeDB:
+    def __init__(self):
+        self.tables = {}
+
+    def table_names(self):
+        return list(self.tables.keys())
+
+    def open_table(self, table_name):
+        return self.tables[table_name]
+
+    def create_table(self, table_name, schema):
+        table = FakeTable()
+        self.tables[table_name] = table
+        return table
+
+
+class FakeLanceDB:
+    def __init__(self):
+        self.databases = {}
+
+    def connect(self, path):
+        if path not in self.databases:
+            self.databases[path] = FakeDB()
+        return self.databases[path]
+
+
+# ---------- Role-aware mock cognitive core ----------
+
+class RoleAwareMockCognitiveCore(CognitiveCore):
+    """Returns canned JSON responses keyed by [[ROLE:Name]] marker in the prompt.
+
+    Pass `responses={"CEO": {"output": {...}, "next_role": "RnD"}, ...}` to wire each
+    role independently. Call `set_response("CEO", new_response)` mid-test to change
+    behavior dynamically (e.g. for the QA-reject-and-retry test).
+    """
+
+    def __init__(self, responses: dict[str, dict] | None = None):
+        self.responses: dict[str, dict] = dict(responses or {})
+        self.call_history: list[tuple[str, str]] = []  # (role_name, prompt)
+
+    def set_response(self, role_name: str, response: dict) -> None:
+        self.responses[role_name] = response
+
+    def generate_response(self, inputs: dict, **kwargs) -> str:
+        prompt = inputs.get("text_data", "") if isinstance(inputs, dict) else str(inputs)
+        match = re.search(r"\[\[ROLE:([A-Za-z]+)\]\]", prompt)
+        role = match.group(1) if match else "UNKNOWN"
+        self.call_history.append((role, prompt))
+        response = self.responses.get(role)
+        if response is None:
+            response = {"output": {"error": f"no canned response for {role}"}, "next_role": None}
+        return json.dumps(response)
+
+    def load_model(self, model_path: str) -> None:
+        pass
+
+    def train(self, dataset: Any) -> None:
+        pass
+
+    def get_state(self) -> Any:
+        return None
+
+
+# ---------- Default happy-path responses ----------
+
+def make_happy_path_responses() -> dict[str, dict]:
+    return {
+        "CEO": {
+            "output": {
+                "brief": "Draft an announcement for the new vector embeddings feature.",
+                "success_criteria": [
+                    "Clear value proposition",
+                    "Three paragraphs",
+                    "Target developer audience",
+                ],
+                "risks": ["Audience may need more technical depth"],
+            },
+            "next_role": "RnD",
+        },
+        "RnD": {
+            "output": {
+                "research_summary": "Vector embeddings let semantic search work on free text.",
+                "approach": "Lead with a concrete use case, then describe the technology.",
+                "open_questions": [],
+            },
+            "next_role": "Marketing",
+        },
+        "Marketing": {
+            "output": {
+                "positioning": "Search your codebase by meaning, not keywords.",
+                "key_messages": [
+                    "Drop-in replacement for keyword search",
+                    "Free to run locally",
+                ],
+                "audience": "Developers",
+            },
+            "next_role": "Production",
+        },
+        "Production": {
+            "output": {
+                "deliverable": "We're excited to launch vector embeddings...",
+            },
+            "next_role": "Ops",
+        },
+        "Ops": {
+            "output": {
+                "channel": "email",
+                "recipient": "users@example.com",
+                "subject": "New: vector embeddings in Chimera",
+                "body_reference": "deliverable",
+                "when": "now",
+            },
+            "next_role": "QA",
+        },
+        "QA": {
+            "output": {
+                "verdict": "approved",
+                "reason": "Meets all three success criteria; Ops plan is safe.",
+            },
+            "next_role": None,
+        },
+    }
+
+
+# ---------- Pytest fixtures ----------
+
+@pytest.fixture(autouse=True)
+def fake_vector_deps(monkeypatch):
+    fake_lance = FakeLanceDB()
+    monkeypatch.setattr(
+        "chimera.agent.memory._load_vector_dependencies",
+        lambda: (fake_lance, FakeArrow, FakeSentenceTransformer),
+    )
+    return fake_lance
+
+
+@pytest.fixture
+def tmp_db_root(tmp_path):
+    root = tmp_path / "chimera_org"
+    root.mkdir()
+    return str(root)
+
+
+@pytest.fixture
+def happy_responses():
+    return make_happy_path_responses()
+
+
+@pytest.fixture
+def happy_core(happy_responses):
+    return RoleAwareMockCognitiveCore(happy_responses)

--- a/agi-project/tests/test_org/test_org_sequential.py
+++ b/agi-project/tests/test_org/test_org_sequential.py
@@ -1,0 +1,94 @@
+"""End-to-end sequential org tests: 6-role happy path and reject-and-retry."""
+
+import os
+
+from chimera.org.org import Org
+from chimera.org.work_order import OrgStatus
+
+
+def test_six_role_happy_path(happy_core, tmp_db_root):
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+    wo = org.submit("Draft a 3-paragraph announcement for vector embeddings")
+    final = org.run_until_complete(wo.id)
+
+    assert final.status == OrgStatus.COMPLETED
+    assert final.assigned_role is None
+
+    # Each of the six roles touched the WorkOrder exactly once.
+    roles_visited = [entry["role"] for entry in final.history]
+    assert roles_visited == ["CEO", "RnD", "Marketing", "Production", "Ops", "QA"]
+
+    # All expected artifacts are present.
+    for key in ("brief", "research", "positioning", "deliverable", "ops_plan", "qa_verdict"):
+        assert key in final.artifacts
+
+
+def test_qa_reject_then_approve(happy_core, tmp_db_root):
+    """QA rejects on first pass; Production redoes; QA approves on second pass."""
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+
+    # State machine for the QA mock: reject first, approve second.
+    call_state = {"qa_calls": 0}
+    original_generate = happy_core.generate_response
+
+    def patched_generate(inputs, **kwargs):
+        prompt = inputs.get("text_data", "")
+        if "[[ROLE:QA]]" in prompt:
+            call_state["qa_calls"] += 1
+            if call_state["qa_calls"] == 1:
+                import json
+                return json.dumps(
+                    {
+                        "output": {
+                            "verdict": "rejected",
+                            "reason": "Production output too short",
+                        },
+                        "next_role": None,
+                    }
+                )
+        return original_generate(inputs, **kwargs)
+
+    happy_core.generate_response = patched_generate  # type: ignore[method-assign]
+
+    wo = org.submit("Write a launch tweet")
+    final = org.run_until_complete(wo.id, max_hops=20)
+
+    assert final.status == OrgStatus.COMPLETED
+    assert call_state["qa_calls"] == 2
+    # Production appeared twice (original + revision), QA twice (reject + approve).
+    roles_visited = [entry["role"] for entry in final.history]
+    assert roles_visited.count("Production") == 2
+    assert roles_visited.count("QA") == 2
+
+
+def test_double_reject_fails(happy_core, tmp_db_root):
+    """QA rejects twice -> WorkOrder marked FAILED."""
+    happy_core.set_response(
+        "QA",
+        {
+            "output": {"verdict": "rejected", "reason": "still not good"},
+            "next_role": None,
+        },
+    )
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+    wo = org.submit("Goal that will fail")
+    final = org.run_until_complete(wo.id, max_hops=20)
+
+    assert final.status == OrgStatus.FAILED
+    assert final.reject_count == 2
+
+
+def test_org_persists_to_sqlite(happy_core, tmp_db_root):
+    """After running, the SQLite store should contain the completed WorkOrder."""
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+    wo = org.submit("persist me")
+    final = org.run_until_complete(wo.id)
+
+    # Reload from a brand-new store pointing at the same file.
+    from chimera.org.store import WorkOrderStore
+
+    store2 = WorkOrderStore(db_path=os.path.join(tmp_db_root, "org.sqlite3"))
+    reloaded = store2.load(final.id)
+    assert reloaded is not None
+    assert reloaded.status == OrgStatus.COMPLETED
+    assert len(reloaded.history) == 6

--- a/agi-project/tests/test_org/test_persistence.py
+++ b/agi-project/tests/test_org/test_persistence.py
@@ -1,0 +1,58 @@
+"""Crash-and-resume: simulate a failure mid-flow and verify Org.resume() finishes the job."""
+
+import json
+import os
+import pytest
+
+from chimera.org.org import Org
+from chimera.org.work_order import OrgStatus
+
+
+def test_crash_after_rnd_then_resume(happy_core, tmp_db_root):
+    """Simulate the Marketing role raising on its first invocation. The persisted state
+    should still show ASSIGNED to Marketing (last successful save was after R&D).
+    Then on resume, allow Marketing through and verify the flow completes."""
+
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+
+    original_generate = happy_core.generate_response
+    crash_state = {"crashed": False}
+
+    def patched_generate(inputs, **kwargs):
+        prompt = inputs.get("text_data", "")
+        if "[[ROLE:Marketing]]" in prompt and not crash_state["crashed"]:
+            crash_state["crashed"] = True
+            raise RuntimeError("simulated crash during Marketing")
+        return original_generate(inputs, **kwargs)
+
+    happy_core.generate_response = patched_generate  # type: ignore[method-assign]
+
+    wo = org.submit("crash test")
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        org.run_until_complete(wo.id)
+
+    # After the crash, the persisted store should show the WO still ASSIGNED to Marketing
+    # (the role from which the run was attempted) because the save after R&D's advance
+    # already routed it there.
+    reloaded = org.store.load(wo.id)
+    assert reloaded is not None
+    assert reloaded.status == OrgStatus.ASSIGNED
+    assert reloaded.assigned_role == "Marketing"
+    # CEO and R&D both ran before the crash.
+    roles_so_far = [h["role"] for h in reloaded.history]
+    assert roles_so_far == ["CEO", "RnD"]
+
+    # Now resume: Marketing should run successfully on the second attempt and the flow completes.
+    finals = org.resume(max_hops=20)
+    assert len(finals) == 1
+    final = finals[0]
+    assert final.status == OrgStatus.COMPLETED
+    roles_visited = [h["role"] for h in final.history]
+    assert roles_visited == ["CEO", "RnD", "Marketing", "Production", "Ops", "QA"]
+
+
+def test_resume_with_no_active_workorders(happy_core, tmp_db_root):
+    """resume() on an empty store returns an empty list, no errors."""
+    org = Org.default(cognitive_core=happy_core, db_root=tmp_db_root)
+    finals = org.resume()
+    assert finals == []

--- a/agi-project/tests/test_org/test_role.py
+++ b/agi-project/tests/test_org/test_role.py
@@ -1,0 +1,93 @@
+"""Per-role tests: each Role.process produces the right artifact and handoff."""
+
+import pytest
+
+from chimera.org.roles import (
+    CEORole,
+    MarketingRole,
+    OpsRole,
+    ProductionRole,
+    QARole,
+    RnDRole,
+)
+from chimera.org.work_order import OrgStatus, WorkOrder
+
+
+@pytest.fixture
+def make_wo_for(happy_core, tmp_db_root):
+    """Factory: returns a (role_instance, work_order_in_assigned_state) for a given role class."""
+
+    def _make(role_cls):
+        role = role_cls(cognitive_core=happy_core, db_root=tmp_db_root)
+        wo = WorkOrder(goal="test goal")
+        wo.assign_initial(role.name)
+        return role, wo
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    "role_cls,expected_artifact_key,expected_next",
+    [
+        (CEORole, "brief", "RnD"),
+        (RnDRole, "research", "Marketing"),
+        (MarketingRole, "positioning", "Production"),
+        (ProductionRole, "deliverable", "Ops"),
+        (OpsRole, "ops_plan", "QA"),
+    ],
+)
+def test_role_advances_with_expected_artifact(
+    make_wo_for, role_cls, expected_artifact_key, expected_next
+):
+    role, wo = make_wo_for(role_cls)
+    role.process(wo)
+    assert expected_artifact_key in wo.artifacts
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == expected_next
+    assert wo.history[-1]["role"] == role.name
+
+
+def test_qa_approval_completes(make_wo_for):
+    role, wo = make_wo_for(QARole)
+    role.process(wo)
+    assert wo.status == OrgStatus.COMPLETED
+    assert wo.artifacts["qa_verdict"]["verdict"] == "approved"
+
+
+def test_qa_rejection_routes_to_production(happy_core, tmp_db_root):
+    happy_core.set_response(
+        "QA",
+        {
+            "output": {"verdict": "rejected", "reason": "not enough detail"},
+            "next_role": None,
+        },
+    )
+    role = QARole(cognitive_core=happy_core, db_root=tmp_db_root)
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("QA")
+    role.process(wo)
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == "Production"
+    assert wo.reject_count == 1
+    assert wo.artifacts["qa_feedback"] == "not enough detail"
+
+
+def test_role_handles_malformed_response(happy_core, tmp_db_root):
+    """If the LLM returns non-JSON, the role should not crash -- it should record an error and advance."""
+
+    class BrokenCore:
+        def generate_response(self, inputs, **kwargs):
+            return "this is not json at all"
+
+        def load_model(self, p): pass
+        def train(self, d): pass
+        def get_state(self): return None
+
+    role = CEORole(cognitive_core=BrokenCore(), db_root=tmp_db_root)
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("CEO")
+    role.process(wo)
+    # Should still have advanced to next role; output captured the parsing error.
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == "RnD"
+    assert "error" in wo.artifacts["brief"]

--- a/agi-project/tests/test_org/test_tool_isolation.py
+++ b/agi-project/tests/test_org/test_tool_isolation.py
@@ -1,0 +1,42 @@
+"""Each role should only see the tools its allowed_tools list grants it."""
+
+import pytest
+
+from chimera.org.roles import (
+    CEORole,
+    MarketingRole,
+    OpsRole,
+    ProductionRole,
+    QARole,
+    RnDRole,
+)
+
+
+@pytest.mark.parametrize(
+    "role_cls,expected_tools",
+    [
+        (CEORole, set()),
+        (RnDRole, {"web_search", "file_system"}),
+        (MarketingRole, set()),
+        (ProductionRole, {"file_system"}),
+        (OpsRole, set()),
+        (QARole, {"file_system"}),
+    ],
+)
+def test_role_tool_grants(happy_core, tmp_db_root, role_cls, expected_tools):
+    role = role_cls(cognitive_core=happy_core, db_root=tmp_db_root)
+    actual = set(role.agent.tool_registry.get_tool_names())
+    assert actual == expected_tools, (
+        f"{role_cls.__name__} expected tools {expected_tools}, got {actual}"
+    )
+
+
+def test_ceo_has_no_web_search(happy_core, tmp_db_root):
+    """Regression guard: Agent.__init__ auto-registers WebSearchTool. Role must strip it."""
+    role = CEORole(cognitive_core=happy_core, db_root=tmp_db_root)
+    assert "web_search" not in role.agent.tool_registry.get_tool_names()
+
+
+def test_rnd_keeps_web_search(happy_core, tmp_db_root):
+    role = RnDRole(cognitive_core=happy_core, db_root=tmp_db_root)
+    assert "web_search" in role.agent.tool_registry.get_tool_names()

--- a/agi-project/tests/test_org/test_work_order.py
+++ b/agi-project/tests/test_org/test_work_order.py
@@ -1,0 +1,95 @@
+"""Unit tests for WorkOrder state machine."""
+
+import pytest
+
+from chimera.org.work_order import IllegalTransition, OrgStatus, WorkOrder
+
+
+def test_initial_state():
+    wo = WorkOrder(goal="hello")
+    assert wo.status == OrgStatus.OPEN
+    assert wo.assigned_role is None
+    assert wo.history == []
+    assert wo.reject_count == 0
+
+
+def test_happy_path_transitions():
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("CEO")
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == "CEO"
+
+    wo.begin()
+    assert wo.status == OrgStatus.IN_PROGRESS
+
+    wo.advance(by_role="CEO", output={"brief": "x"}, next_role="RnD")
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == "RnD"
+    assert len(wo.history) == 1
+    assert wo.history[0]["role"] == "CEO"
+
+
+def test_final_advance_completes():
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("QA")
+    wo.begin()
+    wo.advance(by_role="QA", output={"verdict": "approved"}, next_role=None)
+    assert wo.status == OrgStatus.COMPLETED
+    assert wo.assigned_role is None
+
+
+def test_illegal_transition_raises():
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("CEO")
+    wo.begin()
+    wo.advance(by_role="CEO", output={}, next_role=None)
+    assert wo.status == OrgStatus.COMPLETED
+    # Cannot move out of COMPLETED.
+    with pytest.raises(IllegalTransition):
+        wo.begin()
+
+
+def test_begin_from_open_is_illegal():
+    wo = WorkOrder(goal="g")
+    with pytest.raises(IllegalTransition):
+        wo.begin()
+
+
+def test_first_reject_routes_back():
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("QA")
+    wo.begin()
+    wo.reject(by_role="QA", reason="missing detail", route_back_to="Production")
+    assert wo.status == OrgStatus.ASSIGNED
+    assert wo.assigned_role == "Production"
+    assert wo.reject_count == 1
+    assert wo.artifacts["qa_feedback"] == "missing detail"
+
+
+def test_second_reject_fails():
+    wo = WorkOrder(goal="g")
+    wo.assign_initial("QA")
+    wo.begin()
+    wo.reject(by_role="QA", reason="r1", route_back_to="Production")
+    # Production re-runs and we hit QA again.
+    wo.begin()
+    wo.reject(by_role="QA", reason="r2", route_back_to="Production")
+    assert wo.status == OrgStatus.FAILED
+    assert wo.reject_count == 2
+
+
+def test_serialize_round_trip():
+    wo = WorkOrder(goal="round trip me")
+    wo.assign_initial("CEO")
+    wo.begin()
+    wo.advance(by_role="CEO", output={"brief": "x"}, next_role="RnD")
+
+    payload = wo.to_dict()
+    restored = WorkOrder.from_dict(payload)
+
+    assert restored.id == wo.id
+    assert restored.goal == wo.goal
+    assert restored.status == wo.status
+    assert restored.assigned_role == wo.assigned_role
+    assert restored.history == wo.history
+    assert restored.artifacts == wo.artifacts


### PR DESCRIPTION
Six-role sequential org (CEO, R&D, Marketing, Production, Ops, QA) built on top
of the existing Chimera Agent, Tool, and VectorEpisodicMemory primitives. Zero
new dependencies -- WorkOrder persistence uses stdlib sqlite3.

Phase 1 scope:
- WorkOrder dataclass with explicit state machine (advance / reject / serialize)
- Role base class wrapping Chimera Agent with per-role tool grants and prompts
- Six concrete roles wired into a sequential flow
- Org dispatcher with submit / run_until_complete / resume
- SQLite-backed WorkOrderStore for crash recovery
- ApprovalGate stub (pass-through in Phase 1, enforced in Phase 2)
- CLI entry point: python -m chimera.org submit "<goal>"
- 30 tests covering state transitions, per-role behavior, full 6-role flow,
  QA reject-and-retry, crash-and-resume, and tool isolation

Phases 2-5 (external I/O, skill library, self-improvement loop, dashboard)
are scoped in /root/.claude/plans/before-planning-of-working-cuddly-metcalfe.md.

https://claude.ai/code/session_01CzdZPTXMuha45eHtsWM9n5